### PR TITLE
chore(tools): add codegraph and reversing dev tooling plus the codegr…

### DIFF
--- a/.claude/memory/memory.md
+++ b/.claude/memory/memory.md
@@ -7,3 +7,4 @@ section in `CLAUDE.md` for the rules. Entry format inside each topic file: `date
 |---|---|---|
 | [interactive-ui.md](interactive-ui.md) | Conventions and gotchas for the interactive menus/screens under `ysonet/Interactive/`. | 2026-07-22 |
 | [testing.md](testing.md) | Test-harness gotchas: where tests write files, and antivirus/compile hangs. | 2026-07-22 |
+| [workflow.md](workflow.md) | Git/multi-agent workflow: use a git worktree (or at least a new branch) for new or parallel work so agents don't share one checkout. | 2026-07-22 |

--- a/.claude/memory/workflow.md
+++ b/.claude/memory/workflow.md
@@ -1,0 +1,5 @@
+# Workflow
+
+Git and multi-agent working conventions. Entry format: `date - what - why`.
+
+- 2026-07-22 - When starting new or parallel work that will live on its own branch, give the agent an isolated checkout with a git worktree (`git worktree add ../ysonet-<topic> master`, then work on a branch inside it) instead of sharing the one repo checkout. At minimum, use a dedicated branch. - Two agents sharing a single working tree block each other: you cannot switch off or delete the branch that is checked out, and switching branches reverts and clobbers the other agent's uncommitted work-in-progress. A separate worktree gives each agent its own working directory, so branches can be created, switched, and deleted freely without ever touching the other agent's files. This came up when a branch could not be deleted because a second agent was mid-edit in the same checkout.

--- a/.claude/skills/ysonet-codegraph/SKILL.md
+++ b/.claude/skills/ysonet-codegraph/SKILL.md
@@ -1,0 +1,250 @@
+---
+name: ysonet-codegraph
+description: Query the ysonet C# code graph (call / containment / inheritance / attribute edges). Use whenever you need to find where a method is called from, what it calls, call chains between two functions, class members, containing class/module, attributes/modifiers, or to do code review, security review, deserialization gadget hunting, or source-to-sink / sink-to-source (taint) reachability over the ysonet C# source. Never read or grep the multi-GB *.json graph file directly - query it through the codegraph CLI below.
+---
+
+# codegraph - ysonet code graph queries
+
+All queries go through the CLI (fast, ~0.1-0.4 s per call; the index is built
+once and reused):
+
+```
+python tools/codegraph/codegraph.py <command> [args]
+```
+
+The tool needs to know which graph JSON to read. Point it at the built ysonet
+code graph in one of two ways:
+
+- set it once per shell: `export CODEGRAPH_GRAPH=<path-to-ysonet-graph.json>`
+  (PowerShell: `$env:CODEGRAPH_GRAPH = "<path>"`), then every command below runs
+  as written; or
+- pass `--graph <path>` on each call.
+
+With neither set the tool errors with `graph JSON not found (use --graph <path>
+or CODEGRAPH_GRAPH)`. The graph is large (often multi-GB) and is built by the
+C# graph makers. It lives under the git-ignored `local/` folder and is never
+committed (the generated graph may be copyrighted, so it is kept out of the
+public repo). If the command above cannot find a graph, ask where it is or
+build it first.
+
+The tool auto-detects whether a graph is **resolved** (Roslyn/Cecil-built,
+`resolved_calls: 1`: `calls`/`inherits`/`implements`/`type_uses`/`overrides`
+edges point at real nodes) or **heuristic** (calls recorded as name strings).
+The ysonet C# graph built by the Roslyn maker is resolved, so `callers`/
+`callees`/`path` are exact, and it also carries properties, fields, events,
+attributes, and accessibility modifiers. The recipes below assume a resolved
+graph; on a heuristic graph, name-matched aliases are folded in and marked `~`.
+
+## Commands
+
+| Goal | Command |
+|---|---|
+| find a node by name | `search <text> [--kind method\|class\|module\|ext] [--file <substr>] [-n 20] [--offset N]` |
+| node details + containing class/module | `node <ref> [--full]` |
+| where is it called from (tree toward origins) | `callers <ref> [--depth 2-3] [-n 30]` |
+| what does it call (tree toward targets) | `callees <ref> [--depth 2] [-n 30]` |
+| members of a class/module | `callees <ref> --kind contains` |
+| who inherits / implements it | `callers <ref> --kind inherits` (or `implements`) |
+| call chain between two nodes | `path <a> <b> [--undirected] [--via-ext]` |
+| **find nodes matching a pattern** | `find <predicates>` (see below) |
+| graph overview | `stats` |
+| anything else | `sql "select ..."` (read-only; schema below) |
+
+## find - pattern matching (conjunction of predicates)
+
+`find` returns nodes where ALL given conditions hold. Repeatable flags add
+conditions.
+
+```
+find [--kind <k>] [--name <substr>] [--file <substr>] [--mods a,b]
+     [--attr <substr> ...]          node has an attribute whose name contains substr
+     [--implements <substr> ...]    implements an interface matching substr
+     [--inherits <substr> ...]      inherits a base matching substr
+     [--uses <substr> ...]          references a type matching substr (type_uses)
+     [--overrides <substr> ...]     overrides a member matching substr
+     [--calls <substr> ...]         (methods) has an outgoing call to a match (1 hop)
+     [--reaches <substr> ...]       can REACH a target via calls within --reach-depth
+                                    hops (transitive; source->sink, multi-hop gadgets)
+     [--reached-by <substr> ...]    is reachable FROM a source (reverse)
+     [--reach-depth N]              max hops for reaches/reached-by (default 4)
+     [--member <spec> ...]          contains a member matching spec
+     [-n N] [--offset N]
+```
+
+`--reaches`/`--reached-by` do a bounded call-graph walk in Python, so put a
+structural predicate first (e.g. `--kind method`) to narrow candidates - an
+unnarrowed reach scan is capped and will say so. `reaches=` is also a `--member`
+token, e.g. `--member "constructor:reaches=binaryformatter.deserialize"` =
+"a class with a ctor that transitively reaches BinaryFormatter" (bridge gadget).
+
+`--member` spec = `kind[:tok,tok,...]` where toks are modifiers the member must
+have (`public`/`get`/`set`/`static`/...) plus: `params=0`/`params=+`,
+`type=<substr>` (member's own type - works for primitives too), `calls=<substr>`
+(member calls a matching target, 1 hop), `uses=<substr>` (signature references a
+type via type_uses), and `reaches=<substr>` (member transitively reaches a target
+via calls - multi-hop). Examples: `constructor:public,params=0`,
+`property:public,get,set`, `field:type=DataSet`, `method:calls=invoke`
+(ObjectDataProvider shape), `constructor:reaches=binaryformatter.deserialize`
+(bridge gadget).
+
+Example - classes serializable+deserializable by BinaryFormatter and Json.NET
+(i.e. `[Serializable]`, a public parameterless ctor, and a public read/write
+property), optionally requiring `ISerializable`:
+
+```
+find --kind class --attr serializable \
+     --member "constructor:public,params=0" \
+     --member "property:public,get,set"
+# add --implements ISerializable to also require the ISerializable contract
+```
+
+`<ref>` = `#123` or `123` (node number shown in every output line - always prefer
+these), a full node id, or a unique substring. Add `--json` to any command for
+machine-readable output (usually unnecessary; text is fewer tokens).
+
+## Workflow
+
+1. `search ModuleEditor --kind class` -> pick the right `#id` from the results.
+2. `node #232` -> file:lines, `container:` chain, params, complexity, edge counts.
+3. `callers #232 --depth 2` / `callees #232` -> trace in either direction.
+
+## Reading the output
+
+```
+#232 fn ModuleEditor.Render  ModuleEditor.cs:39
+```
+`#id kind label file:line`; `x2` (if present) = edge appeared twice; `~` =
+inferred (only on heuristic graphs); `^` = node already shown above (cycle, not
+re-expanded). Kinds: `fn` method/function, `cls` class, `ctor` constructor,
+`prop` property, `fld` field, `evt` event, `op` operator, `del` delegate, `ifc`
+interface, `str` struct, `enum`, `enumv` enum-member, `ns` namespace, `ext`
+external/unresolved target (BCL/NuGet APIs outside the graphed ysonet source).
+Trees indent under the node that reached them, so a chain reads top-to-bottom as
+a call path. Lists are paginated - `[k/total shown]` / `[truncated at N]`; only
+raise `-n`/`--offset` when needed.
+
+Exit code 2 = not found or ambiguous; candidate list is printed on stderr -
+pick one and retry with its `#id`.
+
+## Quirks
+
+- On a resolved graph, `callers`/`callees` are exact (no `[+N alias targets]`
+  alias-folding, no `~` unresolved-guess markers on real edges). Unresolved
+  external calls (things outside the graphed ysonet source, e.g. BCL/NuGet APIs)
+  still show up as `ext` nodes - that is expected, not a heuristic artifact.
+- `path` skips `ext` hub nodes as intermediates (they connect unrelated code);
+  pass `--via-ext` only if you explicitly want them (e.g. tracing through a
+  BCL/framework call).
+
+## Graph scope
+
+The graph covers the ysonet C# source that the graph maker ingested. It has real
+`calls` edges plus properties, fields, events, **attributes** (`has_attribute`),
+accessibility **modifiers** (`mods` column, e.g. "public get set"), and
+`overrides` / `type_uses` edges - reliable for security / source-sink / taint
+work. External code (BCL, NuGet packages, framework internals) is not graphed;
+those calls appear as `ext` nodes and are not walked into. For anything outside
+the graphed C# source, fall back to `Grep`/`Glob`.
+
+## Security, source-to-sink and review recipes
+
+Calls are directed caller -> callee. So:
+
+- **source -> sink** (does/how a source reaches a sink): `path <source> <sink>`
+  for the shortest call chain, or `callees <source> --depth N` for the forward
+  reachable set (a tree toward sinks).
+- **sink -> source** (what can reach a dangerous sink, back toward entry points
+  / untrusted input): `callers <sink> --depth N` (a tree toward origins).
+- **find sinks / sources** by API: `search <Api>` (e.g. `Process.Start`,
+  `SqlCommand`, `Deserialize`, `File.ReadAll`), then take the `#id`. Or with
+  `sql`, e.g. callers of any method named like a sink:
+  `sql "select s.label, t.label from edges e join nodes s on s.id=e.src join nodes t on t.id=e.dst join ekinds k on k.id=e.kind where k.name='calls' and t.lname like '%.deserialize'"`
+- **code review of a unit**: `node <id>` (signature, complexity, attributes,
+  container), `callees <id>` (its dependencies), `callers <id>` (its blast
+  radius); rank complexity hotspots with
+  `sql "select id,label,cc from nodes order by cc desc limit 20"`.
+- **attribute/shape checks** (resolved graphs): join `has_attribute` and `mods`
+  in `sql` - e.g. classes that are `[Serializable]` with public read/write
+  properties, or methods marked `[Obsolete]`.
+
+## Deserialization gadget hunting
+
+ysonet builds deserialization payloads, so gadget shapes are a primary review
+target. A **gadget** is a type a serializer will instantiate/populate during
+deserialization whose side effects (constructor, property setters, deserialization
+callbacks, finalizer) can be steered toward a dangerous sink. Gadget hunting
+works directly on the resolved graph (scoped to the graphed ysonet C# source; it
+has no visibility into BCL/NuGet/framework types, only how ysonet code uses them).
+
+**1. Find candidate gadgets for a serializer** - the "is this type a target?"
+condition differs per serializer; express it with `find`:
+
+| serializer(s) | what makes a type a target | find query |
+|---|---|---|
+| BinaryFormatter, SoapFormatter, LosFormatter, ObjectStateFormatter, NetDataContractSerializer | `[Serializable]` or `ISerializable` | `find --kind class --attr serializable` / `find --kind class --implements ISerializable` |
+| DataContractSerializer, DataContractJsonSerializer | `[DataContract]` (often with `[KnownType]`) | `find --kind class --attr datacontract` |
+| Json.NET (Newtonsoft), JavaScriptSerializer, most JSON | public type, parameterless ctor, settable members | `find --kind class --member "constructor:public,params=0" --member "property:public,set"` (also `--attr jsonobject`) |
+| XmlSerializer | public parameterless ctor + public read/write members | `find --kind class --member "constructor:public,params=0" --member "property:public,get,set"` |
+
+Narrow to *dangerous* gadgets with a behavioral member condition, e.g. a
+reflection-invoking gadget like ObjectDataProvider (which is NOT `[Serializable]`
+- attribute rules miss it):
+`find --kind class --member "method:calls=invoke" --member "property:public,set" --member "constructor:public,params=0"`
+or require `--implements IDeserializationCallback`, or combine with step 3.
+
+**2. From a known gadget G (its #id), expand the gadget/sink set:**
+
+- classes that **extend** it (subclasses are gadgets too):
+  `callers <G> --kind inherits --depth 5`  (or `find --kind class --inherits <Gname>`)
+- **implementers** (if G is an interface): `callers <G> --kind implements`
+- classes/members that **use** it (hold or construct it -> can become sinks):
+  `callers <G> --kind type_uses` (signature references) and
+  `callers <Gctor> --kind calls` (constructions). The labels show
+  `Container.Member`, so you see the using class.
+- who **overrides** its magic method: `callers <G.Member> --kind overrides`
+
+**3. Find bridge gadgets by rule (no names) - multi-hop:** a `[Serializable]`
+class whose deserialization constructor transitively reaches a formatter:
+```
+find --kind class --implements ISerializable \
+     --member "constructor:reaches=binaryformatter.deserialize"
+```
+Drop `--implements ISerializable` or raise `--reach-depth` for wider recall;
+use getter gadgets via `find --kind property --reaches binaryformatter.deserialize`.
+This only sees gadget chains within the graphed ysonet source; it cannot follow
+a chain into BCL/NuGet/framework internals, which are not graphed.
+
+**4. Confirm a gadget/user is dangerous (reaches a sink):**
+
+- list its deserialization-triggered members: `callees <G> --kind contains`
+  (look at setters, `OnDeserialized`, `OnDeserialization`, ctor, finalizer);
+- trace each toward a sink: `callees <member> --depth 4` or
+  `path <member> <sink>`;
+- find sinks first with `find --kind method --calls <DangerousApi>` (e.g.
+  `Process.Start`, `Assembly.Load`, `Activator.CreateInstance`, `File.`,
+  `Marshal.`), then `callers <sink> --depth N` to see what reaches them.
+
+This same shape (find a property/edge condition, then traverse callers/callees
+or path) covers general bug hunting too - e.g. unvalidated input reaching a
+sink, classes missing an attribute, overrides of a security-sensitive method.
+
+## SQL schema (for the `sql` command)
+
+```
+nodes(id, name, label, lname, kind, file, line1, line2, cc, nbranch,
+      params, ret, throws, doc, mods, synthetic)
+   -- lname = lower(unescaped name); mods = space-joined modifiers
+   -- (populated on a resolved graph); synthetic = 1 for compiler-generated
+   -- members (e.g. implicit ctors)
+edges(src, dst, kind, conf, n)         -- n = times edge appeared
+files(id, path)  kinds(id, name)  ekinds(id, name)  confs(id, name)  meta(k, v)
+-- joins: nodes.kind->kinds.id, nodes.file->files.id,
+--        edges.src/dst->nodes.id, edges.kind->ekinds.id
+-- ext nodes: id >= (select v from meta where k='nodes')
+```
+Example - top 10 most complex methods:
+`sql "select id, label, cc from nodes order by cc desc limit 10"`
+
+If the index is missing/stale it rebuilds automatically (~22 s for a large
+graph; requires the `ijson` package and prints progress to stderr). Full docs:
+`tools/codegraph/README.md`.

--- a/.gitignore
+++ b/.gitignore
@@ -279,3 +279,4 @@ nuget.config
 BenchmarkDotNet.Artifacts/
 TestResults/
 temp/
+local/

--- a/tools/codegraph/.gitignore
+++ b/tools/codegraph/.gitignore
@@ -1,0 +1,7 @@
+# Python caches and test artifacts - never commit
+__pycache__/
+*.pyc
+.pytest_cache/
+
+# Built SQLite index (created next to a graph JSON, not shipped)
+*.idx.sqlite

--- a/tools/codegraph/LICENSE
+++ b/tools/codegraph/LICENSE
@@ -1,0 +1,22 @@
+Copyright (c) 2026 Soroush Dalili
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/tools/codegraph/README.md
+++ b/tools/codegraph/README.md
@@ -1,0 +1,238 @@
+# codegraph — token-efficient code-graph queries for AI agents
+
+`mygraph.json` (~2 GB, UTF-16) is a call/containment graph of the codebase —
+far too large to read, grep, or put into an AI context window. `codegraph.py`
+answers the two questions an agent actually asks, in as few tokens as possible:
+
+- **where is this called from?** → `callers` (tree toward origins)
+- **what does this call?** → `callees` (tree toward targets)
+
+plus `search` / `node` / `path` / `stats` to find and inspect nodes, and a
+read-only `sql` escape hatch for everything else. Anything expressible through
+those was deliberately removed — fewer commands also means fewer MCP tool
+schemas burning agent-context tokens every session.
+
+## Which graph: `mygraph.json` vs `csgraph.json`
+
+codegraph works with any graph in the supported JSON shape; point it at one with
+`--graph`. Two are available here:
+
+- **`mygraph.json`** — the original polyglot call graph (built by Trail of Bits'
+  trailmark). Broad language coverage; methods/classes/modules only.
+- **`csgraph.json`** — a C#-only graph built by
+  [`graph_makers\csharp_roslyn`](../graph_makers/csharp_roslyn) via Roslyn. Much
+  richer: it also has **properties, fields, events, attributes, accessibility
+  modifiers, and accurately-resolved calls** (only ~9k unresolved targets vs
+  ~240k in mygraph). Use this for member-level or attribute questions — e.g.
+  "which `[Serializable]` classes have a public parameterless ctor and public
+  read/write properties". The extra `modifiers`/`synthetic` data lands in the
+  `mods`/`synthetic` node columns (see SQL schema below).
+
+Both index and query identically; the only difference is how much each graph
+contains. The `graph_makers\csharp_cecil` maker produces more of the same shape
+from compiled DLLs — e.g. `graphs\gac_net2.json`, `graphs\gac_net4.json`,
+`graphs\net10_framework.json` (the .NET Framework GACs and the .NET 10 shared
+frameworks).
+
+**Resolved vs heuristic calls.** Graphs from the C# makers set
+`summary.resolved_calls` = 1: their `calls` edges point at real target nodes, so
+`callers` reports exactly the real callers. `mygraph` records calls as
+name strings (unresolved `ext` targets), so `callers` folds in name-matched
+**aliases** (marked `~`, with `[+N alias targets]`) to recover hidden callers —
+useful there, but heuristic. codegraph detects this per-graph and only applies the
+alias heuristic to unresolved graphs. **For security / source-sink / taint
+reachability, use a resolved graph** (csgraph or a cecil graph), where edges are
+trustworthy:
+
+- source → sink: `path <source> <sink>` (shortest call chain) or
+  `callees <source> --depth N` (forward reachable set).
+- sink → source: `callers <sink> --depth N` (back toward entry points).
+- find sinks/sources by API: `search <Api>` or a `sql` join on `calls`.
+
+## How it works (and why there's no background process needed)
+
+1. **One-time index.** The first query streams the JSON (incremental
+   UTF-16→UTF-8 transcode into `ijson`'s C parser — the file is never loaded
+   into memory) and writes a SQLite index `mygraph.json.idx.sqlite` (~283 MB)
+   next to it: nodes get stable short numbers (`#37479`), edges are
+   deduplicated with counts and indexed in both directions. Measured: ~22 s,
+   ~220 MB peak RAM. The index rebuilds automatically when the JSON's
+   size/mtime changes.
+2. **Per-query process.** Each CLI call opens the index read-only and exits:
+   ~60 ms for traversals, ~170 ms for a whole-graph substring search, ~400 ms
+   for alias-aware `callers` (all including Python startup); ~10 MB working
+   set. All state lives on disk and the OS page cache keeps hot pages warm, so
+   *no daemon is required* — an agent simply shells out per question.
+3. **Optional MCP server.** `python codegraph.py mcp` runs a persistent stdio
+   MCP server exposing the same operations as 7 typed tools
+   (`graph_search`, `graph_node`, `graph_callers`, `graph_callees`,
+   `graph_path`, `graph_stats`, `graph_sql`). Use this when you want the agent
+   to call tools instead of running shell commands, including arbitrary
+   read-only SQL. Register in Claude Code with:
+
+   ```
+   claude mcp add codegraph -- python tools/codegraph/codegraph.py mcp
+   ```
+
+   Both modes share the same index and the same code path; the CLI is the
+   simpler default, MCP saves the ~0.2 s process startup and gives schema'd
+   tools.
+
+## Commands
+
+```text
+python codegraph.py <command> [args] [--graph <path>] [--json]
+
+search <text>      find nodes by substring (case-insensitive)
+                   [--kind method|class|module|ext] [--file <path-substr>]
+                   [-n 20] [--offset N]
+node <ref>         one node: id, file:lines, containing class/module chain,
+                   cc, params, returns, throws, doc, edge counts  [--full]
+find               nodes matching a CONJUNCTION of patterns:
+                   [--kind k] [--name s] [--file s] [--mods a,b]
+                   [--attr s ...] [--implements s ...] [--inherits s ...]
+                   [--uses s ...] [--overrides s ...] [--calls s ...]
+                   [--reaches s ...] [--reached-by s ...] [--reach-depth N]
+                   [--member "kind:mod,mod,params=0|+,calls=s,uses=s,reaches=s" ...]
+                   e.g. find --kind class --attr serializable
+                        --member "constructor:public,params=0"
+                        --member "property:public,get,set"
+                   (gadget hunting: --inherits/--uses/--implements a known
+                    gadget; see the codegraph skill for per-serializer recipes)
+callers <ref>      tree of who calls it (toward origins)
+                   [--depth 1] [--kind calls|contains|inherits|implements|any] [-n 30]
+callees <ref>      tree of what it calls (toward targets)  (same options)
+path <a> <b>       shortest path  [--kind calls] [--undirected] [--via-ext]
+                   [--max-depth 15]
+stats              graph overview
+sql "<select>"     read-only SQL against the index  [-n 50]
+index              force-rebuild the index
+mcp                run as MCP stdio server
+```
+
+`<ref>` is `#123` / `123` (the node number shown in every output line), a full
+node id, or a unique substring. The graph file is found via `--graph`, the
+`CODEGRAPH_GRAPH` env var, or `mygraph.json` next to the script. `--json` switches
+any command to compact machine-readable output.
+
+### Recipes
+
+| Question | Command |
+|---|---|
+| find a method | `search CheckTicksRange --kind method` |
+| where do calls come from (transitively) | `callers #37479 --depth 3` |
+| what does it call (transitively) | `callees #37479 --depth 2` |
+| what class/module is it in | `node #37479` (the `container:` line) |
+| members of a class/module | `callees #37474 --kind contains` |
+| call chain between two nodes | `path #a #b` |
+| who inherits from it | `callers #37474 --kind inherits` |
+| most complex / most called | `sql "select id,label,cc from nodes order by cc desc limit 10"` |
+
+### Output legend
+
+```
+#37479 fn CheckTicksRange  HijriCalendar.cs:182 x2 ~
+│      │  │                │                    │  └ inferred (not certain)
+│      │  │                │                    └ edge seen 2 times in source
+│      │  │                └ file basename : start line
+│      │  └ short label (full id via `node`)
+│      └ fn=method/function cls=class mod=module ns=namespace
+│        ext=external/unresolved target
+└ node handle, usable as <ref> anywhere
+^                node already shown above (cycle/repeat); not re-expanded
+[+N alias targets]  callers also searched N unresolved forms of this method
+[truncated at N] / [k/total shown]  use --limit / --offset for more
+```
+
+Exit codes: `0` ok, `2` not found / ambiguous (candidate list on stderr).
+
+### Unresolved call targets (important)
+
+The source graph records most calls as raw strings (`this.CheckTicksRange`,
+`stringBuilder.Append`) rather than resolved node ids. These become `ext`
+nodes. `callers` transparently folds them in: callers of a method include
+callers of its plausible unresolved forms (`this.X`, `Class.X`, bare `X`;
+suffix-matched, capped to qualified forms when the name is too common). Such
+results are heuristic — they carry the `~` (inferred) marker, and a
+`this.X` call from another class may match. `callees` needs no such handling
+(its targets are simply shown as `ext` nodes). Because ext "hub" nodes connect
+unrelated code, `path` skips them as intermediates unless `--via-ext`.
+
+## SQL schema (for `sql` / `graph_sql`)
+
+```
+nodes(id, name, label, lname, kind, file, line1, line2, cc, nbranch,
+      params, ret, throws, doc, mods, synthetic)
+   -- lname = lower(unescaped name)
+   -- mods  = space-joined modifiers e.g. "public get set" (NULL if the graph
+   --         has none, e.g. mygraph). Match with: mods LIKE '%set%'
+   -- synthetic = 1 for compiler-generated members (e.g. implicit constructors)
+edges(src, dst, kind, conf, n)         -- n = times seen in source graph
+files(id, path)   kinds(id, name)   ekinds(id, name)   confs(id, name)
+meta(k, v)
+-- joins: nodes.kind->kinds.id, nodes.file->files.id,
+--        edges.src/dst->nodes.id, edges.kind->ekinds.id, edges.conf->confs.id
+-- external nodes are exactly those with id >= (select v from meta where k='nodes')
+```
+
+Example using the richer `csgraph.json` — `[Serializable]` classes that are
+also Json.NET-friendly (public parameterless ctor + public read/write props):
+
+```sql
+WITH ser AS (SELECT e.src cls FROM edges e JOIN nodes t ON t.id=e.dst
+  JOIN ekinds k ON k.id=e.kind
+  WHERE k.name='has_attribute' AND t.lname LIKE '%serializableattribute'),
+ctor AS (SELECT ce.src cls FROM edges ce JOIN nodes m ON m.id=ce.dst
+  JOIN kinds mk ON mk.id=m.kind JOIN ekinds ek ON ek.id=ce.kind
+  WHERE ek.name='contains' AND mk.name='constructor'
+    AND m.params IS NULL AND m.mods LIKE '%public%'),
+prop AS (SELECT ce.src cls FROM edges ce JOIN nodes p ON p.id=ce.dst
+  JOIN kinds pk ON pk.id=p.kind JOIN ekinds ek ON ek.id=ce.kind
+  WHERE ek.name='contains' AND pk.name='property'
+    AND p.mods LIKE '%public%' AND p.mods LIKE '%get%' AND p.mods LIKE '%set%')
+SELECT n.label FROM ser JOIN ctor USING(cls) JOIN prop USING(cls)
+  JOIN nodes n ON n.id=ser.cls GROUP BY ser.cls ORDER BY n.label;
+```
+
+Only `SELECT`/`WITH`/`EXPLAIN` are accepted, and the connection is read-only.
+
+## Snippet for an agent's instructions (e.g. CLAUDE.md)
+
+```markdown
+## Code graph
+A call/containment graph of the codebase is queryable via:
+  python tools/codegraph/codegraph.py <cmd>
+Run with no arguments for help. Flow: `search <name>` -> pick a #id ->
+`callers #id --depth 2` (where it's called from) / `callees #id` (what it
+calls) / `node #id` (details + containing class). Use #id handles, never full
+node ids. Output is paginated; only raise --limit when needed.
+```
+
+## Development
+
+- **Run tests:** `python -m pytest` (in this directory). 48 tests, <1 s.
+- **Type check:** `python -m pyright codegraph.py tests` (pyright is Pylance's
+  engine; the code is kept clean against it).
+- **Layout:** everything is in `codegraph.py` (indexer → query layer → commands →
+  MCP server → CLI wiring, in that order). Tests live in `tests/`:
+  - `conftest.py` — a tiny synthetic graph mirroring the real file's quirks
+    (UTF-16 BOM, `\.`-escaped ids, dict-shaped fields, duplicate edges,
+    unresolved targets, a call cycle), with the expected node numbering in
+    `ID`; build/CLI helpers (`run_cli`).
+  - `test_unit.py` — pure helpers (labels, escaping, coercion, transcoder,
+    encoding sniffing).
+  - `test_cli.py` — every command end-to-end, including index staleness.
+  - `test_mcp.py` — real JSON-RPC round-trip against an `mcp` subprocess.
+- **Extending:** add a command function `cmd_x(g, a)`, a subparser, a dispatch
+  entry, and (if agents should see it) an entry in `MCP_TOOLS` — the MCP
+  server reuses the CLI path, so one implementation serves both. Add expected
+  behavior to `test_cli.py`; extend the fixture in `conftest.py` by appending
+  edges *last* to keep existing node numbers stable.
+- **Requires:** Python 3.9+; `pip install ijson` (index build only),
+  `pip install pytest pyright` (development only).
+
+## License
+
+Copyright (c) 2026 Soroush Dalili. Licensed under the same MIT License as YSoNet. See
+[`LICENSE`](LICENSE). The copyright and permission notices must remain in all copies or
+substantial portions of this tool.

--- a/tools/codegraph/codegraph.py
+++ b/tools/codegraph/codegraph.py
@@ -1,0 +1,1545 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Soroush Dalili
+# SPDX-License-Identifier: MIT
+"""codegraph - memory- and token-efficient query tool for a large code-graph JSON.
+
+Indexes a multi-GB graph JSON (UTF-16 or UTF-8) once into a compact SQLite
+database, then answers queries instantly with tiny memory and terse output
+designed for AI agents (short #id handles instead of 150-char node ids).
+
+Requires: python 3.9+, ijson (only for the one-time `index` step).
+"""
+
+import argparse
+import codecs
+import contextlib
+import io
+import json
+import os
+import sqlite3
+import sys
+import time
+
+INDEX_VERSION = 2  # v2: added nodes.mods / nodes.synthetic columns
+CHUNK = 1 << 20
+
+# ---------------------------------------------------------------------------
+# helpers
+
+
+def unescape(s: str) -> str:
+    """Graph ids escape literal dots as '\\.'; undo that for display/search."""
+    return s.replace("\\.", ".")
+
+
+def make_label(s: str) -> str:
+    """Short display name: after last ':', else last segment split on
+    unescaped '.', then unescaped."""
+    i = s.rfind(":")
+    if i >= 0:
+        return unescape(s[i + 1:])
+    j = len(s) - 1
+    while j > 0:
+        if s[j] == "." and s[j - 1] != "\\":
+            return unescape(s[j + 1:])
+        j -= 1
+    return unescape(s)
+
+
+KIND_ABBREV = {
+    "function": "fn", "method": "fn", "class": "cls", "module": "mod",
+    "external": "ext", "namespace": "ns", "interface": "ifc", "struct": "str",
+    "enum": "enum", "property": "prop", "field": "fld", "file": "file",
+    "unknown": "?",
+    # extra kinds from the Roslyn / Cecil C# makers
+    "constructor": "ctor", "finalizer": "dtor", "operator": "op",
+    "event": "evt", "delegate": "del", "enum_member": "enumv",
+}
+
+
+def kind_abbrev(name: str) -> str:
+    return KIND_ABBREV.get(name, name[:4])
+
+
+class U16ToU8(io.RawIOBase):
+    """Streams a UTF-16-LE file as UTF-8 bytes (for ijson) without loading it."""
+
+    def __init__(self, f):
+        self.f = f
+        self.dec = codecs.getincrementaldecoder("utf-16-le")()
+        self.buf = bytearray()
+        self.eof = False
+
+    def readable(self):
+        return True
+
+    def read(self, n=-1):
+        if n is None or n < 0:
+            n = 1 << 62
+        while len(self.buf) < n and not self.eof:
+            c = self.f.read(CHUNK)
+            if not c:
+                self.eof = True
+                self.buf += self.dec.decode(b"", True).encode("utf-8")
+                break
+            self.buf += self.dec.decode(c).encode("utf-8")
+        out = bytes(self.buf[:n])
+        del self.buf[:n]
+        return out
+
+    def readinto(self, b):
+        data = self.read(len(b))
+        n = len(data)
+        b[:n] = data
+        return n
+
+
+def open_json_bytes(path):
+    """Returns (utf8_stream_for_ijson, raw_file_for_tell)."""
+    f = open(path, "rb", buffering=CHUNK)
+    head = f.read(3)
+    if head[:2] == b"\xff\xfe":
+        f.seek(2)
+        return U16ToU8(f), f
+    if head == b"\xef\xbb\xbf":
+        return f, f
+    if len(head) >= 2 and head[1] == 0 and head[0] != 0:
+        f.seek(0)
+        return U16ToU8(f), f
+    f.seek(0)
+    return f, f
+
+
+def err(msg):
+    print(msg, file=sys.stderr)
+
+
+# ---------------------------------------------------------------------------
+# index build
+
+SCHEMA = """
+CREATE TABLE meta(k TEXT PRIMARY KEY, v TEXT);
+CREATE TABLE kinds(id INTEGER PRIMARY KEY, name TEXT UNIQUE);
+CREATE TABLE ekinds(id INTEGER PRIMARY KEY, name TEXT UNIQUE);
+CREATE TABLE confs(id INTEGER PRIMARY KEY, name TEXT UNIQUE);
+CREATE TABLE files(id INTEGER PRIMARY KEY, path TEXT UNIQUE);
+CREATE TABLE nodes(
+  id INTEGER PRIMARY KEY,
+  name TEXT NOT NULL,
+  label TEXT NOT NULL,
+  lname TEXT NOT NULL,
+  kind INTEGER NOT NULL,
+  file INTEGER,
+  line1 INTEGER,
+  line2 INTEGER,
+  cc INTEGER,
+  nbranch INTEGER,
+  params TEXT,
+  ret TEXT,
+  throws TEXT,
+  doc TEXT,
+  mods TEXT,        -- space-joined modifiers/accessibility (e.g. "public get set");
+                    -- NULL for graphs that don't emit them (e.g. trailmark)
+  synthetic INTEGER -- 1 for compiler-generated members (e.g. implicit ctors)
+);
+CREATE TABLE edges(src INTEGER, dst INTEGER, kind INTEGER, conf INTEGER, n INTEGER);
+"""
+
+
+class Interner:
+    def __init__(self):
+        self.map = {}
+        self.items = []
+
+    def get(self, name):
+        i = self.map.get(name)
+        if i is None:
+            i = len(self.items)
+            self.map[name] = i
+            self.items.append(name)
+        return i
+
+
+def fmt_param(p):
+    if isinstance(p, dict):
+        n, t = p.get("name"), p.get("type")
+        if t and n:
+            return f"{t} {n}"
+        return str(n or t or "?")
+    return str(p)
+
+
+def as_text(v):
+    """Coerce arbitrarily-shaped JSON values to a short string (or None)."""
+    if v is None or isinstance(v, str):
+        return v
+    if isinstance(v, dict):
+        for k in ("name", "type", "value"):
+            if isinstance(v.get(k), str):
+                return v[k]
+    try:
+        return json.dumps(v, default=str)
+    except (TypeError, ValueError):
+        return str(v)
+
+
+def build_index(graph_path, db_path, quiet=False):
+    try:
+        import ijson
+    except ImportError:
+        err("error: indexing requires the 'ijson' package: pip install ijson")
+        sys.exit(1)
+
+    t0 = time.time()
+    total_bytes = os.path.getsize(graph_path)
+    if os.path.exists(db_path):
+        os.remove(db_path)
+    db = sqlite3.connect(db_path)
+    db.execute("PRAGMA journal_mode=OFF")
+    db.execute("PRAGMA synchronous=OFF")
+    db.execute("PRAGMA temp_store=1")
+    db.execute("PRAGMA cache_size=-65536")
+    db.executescript(SCHEMA)
+
+    kinds, ekinds, confs, files = Interner(), Interner(), Interner(), Interner()
+    name2id = {}
+    next_id = 0
+    nodes_batch = []
+    n_external = 0
+
+    def flush_nodes():
+        nonlocal nodes_batch
+        if nodes_batch:
+            db.executemany(
+                "INSERT INTO nodes VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)", nodes_batch)
+            nodes_batch = []
+
+    def progress(stage, raw):
+        if not quiet:
+            pct = min(99, int(100 * raw.tell() / total_bytes))
+            sys.stderr.write(
+                f"\r{stage} {pct}%  nodes={next_id:,}  {time.time()-t0:.0f}s   ")
+            sys.stderr.flush()
+
+    # --- pass 0: header (language / root_path / summary) -- reads file head only
+    head_meta = {"language": "", "root_path": "", "summary": {}}
+    deps = []
+    src, raw = open_json_bytes(graph_path)
+    for prefix, event, value in ijson.parse(src):
+        if event == "string" and prefix in ("language", "root_path"):
+            head_meta[prefix] = value
+        elif prefix.startswith("summary."):
+            key = prefix[len("summary."):]
+            if key == "dependencies.item":
+                deps.append(value)
+            elif event in ("number", "string"):
+                head_meta["summary"][key] = int(value) if event == "number" else value
+        elif prefix == "nodes" and event == "start_map":
+            break
+    raw.close()
+    head_meta["summary"]["dependencies"] = deps
+
+    # --- pass 1: nodes
+    src, raw = open_json_bytes(graph_path)
+    count = 0
+    for key, nd in ijson.kvitems(src, "nodes"):
+        if key in name2id:
+            continue
+        loc = nd.get("location")
+        if not isinstance(loc, dict):
+            loc = {}
+        params = nd.get("parameters")
+        if not isinstance(params, list):
+            params = []
+        exc = nd.get("exception_types")
+        if not isinstance(exc, list):
+            exc = []
+        br = nd.get("branches")
+        cc = nd.get("cyclomatic_complexity")
+        fp = loc.get("file_path")
+        if not isinstance(fp, str):
+            fp = None
+        base = nd.get("name")
+        if not isinstance(base, str) or not base:
+            base = key
+        try:
+            l1 = int(loc.get("start_line") or 0) or None
+            l2 = int(loc.get("end_line") or 0) or None
+        except (TypeError, ValueError):
+            l1 = l2 = None
+        try:
+            cc = int(cc) if cc is not None else None
+        except (TypeError, ValueError):
+            cc = None
+        mods = nd.get("modifiers")
+        mods = " ".join(str(m) for m in mods) if isinstance(mods, list) and mods else None
+        nodes_batch.append((
+            next_id,
+            key,
+            make_label(base),
+            unescape(key).lower(),
+            kinds.get(as_text(nd.get("kind")) or "unknown"),
+            files.get(fp) if fp else None,
+            l1,
+            l2,
+            cc,
+            len(br) if isinstance(br, list) else 0,
+            "; ".join(fmt_param(p) for p in params) or None,
+            as_text(nd.get("return_type")),
+            ", ".join(str(as_text(x)) for x in exc) or None,
+            as_text(nd.get("docstring")),
+            mods,
+            1 if nd.get("synthetic") else None,
+        ))
+        name2id[key] = next_id
+        next_id += 1
+        count += 1
+        if len(nodes_batch) >= 2000:
+            flush_nodes()
+            if count % 20000 == 0:
+                progress("indexing nodes", raw)
+    flush_nodes()
+    raw.close()
+    n_nodes = next_id
+
+    # --- pass 2: edges (raw -> dedup with counts)
+    ext_kind = kinds.get("external")
+    db.execute("CREATE TABLE eraw(src INTEGER, dst INTEGER, kind INTEGER, conf INTEGER)")
+    eraw_batch = []
+    n_raw_edges = 0
+
+    def node_ref(name):
+        nonlocal next_id, n_external
+        i = name2id.get(name, -1)
+        if i < 0:
+            i = next_id
+            name2id[name] = i
+            next_id += 1
+            n_external += 1
+            un = unescape(name)
+            nodes_batch.append((i, name, un, un.lower(), ext_kind, None, None,
+                                None, None, 0, None, None, None, None, None, None))
+        return i
+
+    src, raw = open_json_bytes(graph_path)
+    for e in ijson.items(src, "edges.item"):
+        s, t = e.get("source"), e.get("target")
+        if not isinstance(s, str) or not isinstance(t, str) or not s or not t:
+            continue
+        eraw_batch.append((
+            node_ref(s),
+            node_ref(t),
+            ekinds.get(as_text(e.get("kind")) or "unknown"),
+            confs.get(as_text(e.get("confidence")) or "unknown"),
+        ))
+        n_raw_edges += 1
+        if len(eraw_batch) >= 5000:
+            db.executemany("INSERT INTO eraw VALUES(?,?,?,?)", eraw_batch)
+            eraw_batch = []
+            flush_nodes()
+            if n_raw_edges % 100000 == 0 and not quiet:
+                sys.stderr.write(
+                    f"\rindexing edges {min(99, int(100 * raw.tell() / total_bytes))}%  "
+                    f"edges={n_raw_edges:,}  {time.time()-t0:.0f}s   ")
+                sys.stderr.flush()
+    if eraw_batch:
+        db.executemany("INSERT INTO eraw VALUES(?,?,?,?)", eraw_batch)
+    flush_nodes()
+    raw.close()
+    name2id.clear()  # free
+
+    if not quiet:
+        sys.stderr.write("\rfinalizing (dedup + indexes)...                              ")
+        sys.stderr.flush()
+    db.execute("INSERT INTO edges SELECT src,dst,kind,conf,COUNT(*) FROM eraw "
+               "GROUP BY src,dst,kind,conf")
+    n_unique = db.execute("SELECT COUNT(*) FROM edges").fetchone()[0]
+    db.execute("DROP TABLE eraw")
+    db.executemany("INSERT INTO kinds VALUES(?,?)", list(enumerate(kinds.items)))
+    db.executemany("INSERT INTO ekinds VALUES(?,?)", list(enumerate(ekinds.items)))
+    db.executemany("INSERT INTO confs VALUES(?,?)", list(enumerate(confs.items)))
+    db.executemany("INSERT INTO files VALUES(?,?)", list(enumerate(files.items)))
+    db.execute("CREATE UNIQUE INDEX idx_nodes_name ON nodes(name)")
+    db.execute("CREATE INDEX idx_edges_src ON edges(src)")
+    db.execute("CREATE INDEX idx_edges_dst ON edges(dst)")
+
+    st = os.stat(graph_path)
+    meta = {
+        "version": INDEX_VERSION,
+        "source_size": st.st_size,
+        "source_mtime": int(st.st_mtime),
+        "language": head_meta["language"],
+        "root_path": head_meta["root_path"],
+        "summary": head_meta["summary"],
+        "nodes": n_nodes,
+        "externals": n_external,
+        "raw_edges": n_raw_edges,
+        "unique_edges": n_unique,
+    }
+    db.executemany("INSERT INTO meta VALUES(?,?)",
+                   [(k, json.dumps(v)) for k, v in meta.items()])
+    db.execute("ANALYZE")
+    db.commit()
+    db.close()
+    if not quiet:
+        sys.stderr.write(
+            f"\rindexed {n_nodes:,} nodes (+{n_external:,} external), "
+            f"{n_raw_edges:,} edges ({n_unique:,} unique) in {time.time()-t0:.0f}s "
+            f"-> {os.path.basename(db_path)} "
+            f"({os.path.getsize(db_path)/1e6:.0f} MB)\n")
+
+
+# ---------------------------------------------------------------------------
+# query layer
+
+
+class G:
+    """Read-only handle over the index."""
+
+    def __init__(self, db_path):
+        self.db = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        self.db.execute("PRAGMA query_only=1")
+        self.db.execute("PRAGMA mmap_size=268435456")
+        self._tails = None
+        self.meta = {k: json.loads(v)
+                     for k, v in self.db.execute("SELECT k,v FROM meta")}
+        self.kinds = [r[1] for r in
+                      self.db.execute("SELECT id,name FROM kinds ORDER BY id")]
+        self.ekinds = [r[1] for r in
+                       self.db.execute("SELECT id,name FROM ekinds ORDER BY id")]
+        self.confs = [r[1] for r in
+                      self.db.execute("SELECT id,name FROM confs ORDER BY id")]
+        self.n = self.meta["nodes"] + self.meta["externals"]
+
+        # Does this graph record calls as unresolved name strings (trailmark /
+        # mygraph) or as resolved edges (the Roslyn/Cecil makers)? It decides
+        # whether `callers` folds in alias targets: that heuristic recovers
+        # hidden callers on an unresolved graph, but injects FALSE callers on a
+        # resolved one (a bare-name match to an unrelated method). Prefer an
+        # explicit summary flag from the maker; otherwise infer from how many
+        # nodes are unresolved external targets (heuristic graphs are ~40-60%
+        # external; resolved graphs are a few percent).
+        rc = (self.meta.get("summary") or {}).get("resolved_calls")
+        if rc is not None:
+            self.heuristic_calls = not rc
+        else:
+            self.heuristic_calls = self.meta["externals"] / max(1, self.n) > 0.25
+
+    def kind_id(self, text):
+        """Match a node-kind by exact name, abbrev, or unique prefix."""
+        t = text.lower()
+        for i, k in enumerate(self.kinds):
+            if k == t or kind_abbrev(k) == t:
+                return i
+        pref = [i for i, k in enumerate(self.kinds) if k.startswith(t)]
+        if len(pref) == 1:
+            return pref[0]
+        raise SystemExit(f"error: unknown kind '{text}' (kinds: {', '.join(self.kinds)})")
+
+    def ekind_id(self, text):
+        if text is None or text == "any":
+            return None
+        t = text.lower()
+        for i, k in enumerate(self.ekinds):
+            if k == t:
+                return i
+        pref = [i for i, k in enumerate(self.ekinds) if k.startswith(t)]
+        if len(pref) == 1:
+            return pref[0]
+        raise SystemExit(
+            f"error: unknown edge kind '{text}' (kinds: {', '.join(self.ekinds)}, any)")
+
+    def node(self, i):
+        return self.db.execute(
+            "SELECT n.id,n.name,n.label,n.kind,f.path,n.line1,n.line2,n.cc,"
+            "n.nbranch,n.params,n.ret,n.throws,n.doc,n.mods,n.synthetic "
+            "FROM nodes n LEFT JOIN files f ON f.id=n.file WHERE n.id=?",
+            (i,)).fetchone()
+
+    def line(self, i, extra=""):
+        r = self.db.execute(
+            "SELECT n.id,n.label,n.kind,f.path,n.line1 "
+            "FROM nodes n LEFT JOIN files f ON f.id=n.file WHERE n.id=?",
+            (i,)).fetchone()
+        if not r:
+            return f"#{i} ?"
+        _, label, kind, path, line1 = r
+        loc = ""
+        if path:
+            loc = f"  {os.path.basename(path)}" + (f":{line1}" if line1 else "")
+        return f"#{i} {kind_abbrev(self.kinds[kind])} {label}{loc}{extra}"
+
+    def row_json(self, i):
+        r = self.db.execute(
+            "SELECT n.id,n.label,n.kind,f.path,n.line1 "
+            "FROM nodes n LEFT JOIN files f ON f.id=n.file WHERE n.id=?",
+            (i,)).fetchone()
+        _, label, kind, path, line1 = r
+        d = {"id": i, "kind": self.kinds[kind], "label": label}
+        if path:
+            d["file"] = path
+            if line1:
+                d["line"] = line1
+        return d
+
+    def edge_suffix(self, n, conf):
+        s = f" x{n}" if n > 1 else ""
+        if self.confs[conf] != "certain":
+            s += " ~"
+        return s
+
+    def _tail_index(self):
+        """last-name-segment -> [(ext id, lname)] for all external nodes."""
+        if self._tails is None:
+            self._tails = {}
+            for i, ln in self.db.execute(
+                    "SELECT id,lname FROM nodes WHERE id>=?",
+                    (self.meta["nodes"],)):
+                self._tails.setdefault(ln.rsplit(".", 1)[-1], []).append((i, ln))
+        return self._tails
+
+    def aliases(self, i):
+        """External nodes that plausibly stand for node i as an unresolved
+        call target (the source graph records most calls as 'this.Method' /
+        'Class.Method' strings rather than resolved node ids). Suffix-matched
+        on the method name; when that is too common (>8 hits) only this- and
+        class-qualified forms are kept."""
+        if i >= self.meta["nodes"]:
+            return []
+        row = self.db.execute("SELECT label FROM nodes WHERE id=?", (i,)).fetchone()
+        if not row:
+            return []
+        label = row[0].lower()
+        tail = label.rsplit(".", 1)[-1]
+        if len(tail) < 2:
+            return []
+        cands = self._tail_index().get(tail, [])
+        if len(cands) > 8:
+            parts = label.split(".")
+            cls = parts[-2] if len(parts) > 1 else None
+            cands = [(j, ln) for j, ln in cands
+                     if ln == "this." + tail or ln == tail
+                     or (cls and ln.endswith(cls + "." + tail))]
+        return [j for j, _ in cands if j != i]
+
+    def resolve(self, ref):
+        """#123 | 123 | exact id | exact label | unique substring.
+        Returns id or exits with candidate list."""
+        r = ref[1:] if ref.startswith("#") else ref
+        if r.isdigit():
+            i = int(r)
+            if 0 <= i < self.n:
+                return i
+            raise SystemExit(f"error: node #{i} out of range (0..{self.n - 1})")
+        row = self.db.execute("SELECT id FROM nodes WHERE name=?", (ref,)).fetchone()
+        if row:
+            return row[0]
+        rows = self.db.execute(
+            "SELECT id FROM nodes WHERE label=? COLLATE NOCASE LIMIT 11",
+            (ref,)).fetchall()
+        if len(rows) == 1:
+            return rows[0][0]
+        pat = unescape(ref).lower()
+        cands = self.db.execute(
+            "SELECT id FROM nodes WHERE instr(lname,?)>0 LIMIT 11", (pat,)).fetchall()
+        if len(cands) == 1:
+            return cands[0][0]
+        if not cands and not rows:
+            err(f"error: no node matches '{ref}'")
+            sys.exit(2)
+        show = rows if len(rows) > 1 else cands
+        err(f"ambiguous ref '{ref}'; candidates:")
+        for (i,) in show[:10]:
+            err("  " + self.line(i))
+        if len(show) > 10:
+            err("  ... (refine the text, or use search)")
+        sys.exit(2)
+
+
+def out_edges(g, i, ekind):
+    q = "SELECT dst,kind,conf,n FROM edges WHERE src=?"
+    args = [i]
+    if ekind is not None:
+        q += " AND kind=?"
+        args.append(ekind)
+    return g.db.execute(q, args).fetchall()
+
+
+def in_edges(g, i, ekind):
+    q = "SELECT src,kind,conf,n FROM edges WHERE dst=?"
+    args = [i]
+    if ekind is not None:
+        q += " AND kind=?"
+        args.append(ekind)
+    return g.db.execute(q, args).fetchall()
+
+
+# ---------------------------------------------------------------------------
+# commands
+
+
+def cmd_stats(g, a):
+    m = g.meta
+    if a.json:
+        kc = {g.kinds[k]: c for k, c in
+              g.db.execute("SELECT kind,COUNT(*) FROM nodes GROUP BY kind")}
+        ec = {g.ekinds[k]: {"unique": u, "raw": r} for k, u, r in
+              g.db.execute("SELECT kind,COUNT(*),SUM(n) FROM edges GROUP BY kind")}
+        print(json.dumps({**m, "node_kinds": kc, "edge_kinds": ec},
+                         separators=(",", ":")))
+        return
+    print(f"graph: {m['language']}  root: {m['root_path']}")
+    print(f"nodes: {m['nodes']:,} (+{m['externals']:,} external targets) "
+          f"-> refs #0..#{g.n - 1}")
+    for k, c in g.db.execute(
+            "SELECT kind,COUNT(*) FROM nodes GROUP BY kind ORDER BY 2 DESC"):
+        print(f"  {g.kinds[k]}: {c:,}")
+    print(f"edges: {m['raw_edges']:,} raw -> {m['unique_edges']:,} unique")
+    for k, u, r in g.db.execute(
+            "SELECT kind,COUNT(*),SUM(n) FROM edges GROUP BY kind ORDER BY 3 DESC"):
+        print(f"  {g.ekinds[k]}: {r:,} ({u:,} unique)")
+    nf = g.db.execute("SELECT COUNT(*) FROM files").fetchone()[0]
+    print(f"files: {nf:,}")
+    deps = m["summary"].get("dependencies", [])
+    shown = ", ".join(deps[:15])
+    more = f" (+{len(deps) - 15} more)" if len(deps) > 15 else ""
+    print(f"deps ({len(deps)}): {shown}{more}")
+    ep = m["summary"].get("entrypoints")
+    if ep is not None:
+        print(f"entrypoints: {ep}")
+
+
+def cmd_search(g, a):
+    pat = unescape(a.text).lower()
+    cond, args = ["instr(n.lname,?)>0"], [pat]
+    if a.kind:
+        cond.append("n.kind=?")
+        args.append(g.kind_id(a.kind))
+    if a.file:
+        cond.append("n.file IN (SELECT id FROM files WHERE instr(lower(path),?)>0)")
+        args.append(a.file.lower())
+    q = (f"SELECT n.id, COUNT(*) OVER () FROM nodes n WHERE {' AND '.join(cond)} "
+         f"ORDER BY n.id LIMIT ? OFFSET ?")
+    rows = g.db.execute(q, args + [a.limit, a.offset]).fetchall()
+    total = rows[0][1] if rows else 0
+    if a.json:
+        print(json.dumps({"total": total,
+                          "offset": a.offset,
+                          "items": [g.row_json(i) for i, _ in rows]},
+                         separators=(",", ":")))
+        return
+    for i, _ in rows:
+        print(g.line(i))
+    if total > a.offset + len(rows):
+        print(f"[{a.offset + len(rows)}/{total} shown; next: --offset {a.offset + len(rows)}]")
+    elif total == 0:
+        print("no matches")
+
+
+def _token_match(col):
+    """SQL fragment matching a whole space-delimited token inside `col`
+    (modifiers are stored space-joined, e.g. 'public get set')."""
+    return f"instr(' '||COALESCE({col},'')||' ', ?)>0"
+
+
+def member_clause(g, spec):
+    """Compiles one --member spec into an EXISTS subclause + its params.
+
+    spec = "<kind>[:tok,tok,...]" where toks are modifiers the member must
+    have (whole-token match, e.g. public/get/set/static) plus the specials
+    `params=0` (parameterless), `params=+` (takes >=1 parameter),
+    `calls=<substr>` (the member calls a target matching substr) and
+    `uses=<substr>` (the member's signature references a type matching substr).
+    The clause is true when the node contains (via a `contains` edge) at least
+    one member matching all of them. Examples:
+        constructor:public,params=0     a public parameterless ctor
+        property:public,get,set         a public read/write property
+        method:calls=invoke             a method that calls something *invoke*
+                                        (e.g. the ObjectDataProvider gadget shape)
+
+    Also accepts `type=<substr>`: the member's own type (field/property type or
+    method return type) contains substr - works for primitives too, unlike
+    `uses=` which is a type_uses edge and skips language primitives.
+
+    Also accepts `reaches=<substr>`: the member can *transitively* reach a
+    target matching substr via calls (multi-hop). Because that is a bounded BFS
+    (not a single SQL join), it is returned separately for Python post-filtering
+    rather than baked into the SQL clause. Returns
+    (sql_clause, sql_args, member_kind, reaches_substrs).
+    """
+    kind_part, _, tok_part = spec.partition(":")
+    kind_name = g.kinds[g.kind_id(kind_part.strip())] if kind_part.strip() else None
+    clause = ("EXISTS(SELECT 1 FROM edges ce JOIN nodes m ON m.id=ce.dst "
+              "JOIN kinds mk ON mk.id=m.kind JOIN ekinds ek ON ek.id=ce.kind "
+              "WHERE ce.src=n.id AND ek.name='contains'")
+    cargs = []
+    reaches = []
+    if kind_name is not None:
+        clause += " AND mk.name=?"
+        cargs.append(kind_name)
+
+    def member_edge(ekind, substr):
+        nonlocal clause
+        clause += (" AND EXISTS(SELECT 1 FROM edges me JOIN nodes mt ON mt.id=me.dst "
+                   "JOIN ekinds mek ON mek.id=me.kind WHERE me.src=m.id "
+                   "AND mek.name=? AND instr(mt.lname,?)>0)")
+        cargs.extend([ekind, unescape(substr).lower()])
+
+    for tok in tok_part.split(","):
+        tok = tok.strip()
+        if not tok:
+            continue
+        low = tok.lower()
+        if low in ("params=0", "params=none", "parameterless"):
+            clause += " AND m.params IS NULL"
+        elif low in ("params=+", "params=any", "hasparams"):
+            clause += " AND m.params IS NOT NULL"
+        elif low.startswith("calls="):
+            member_edge("calls", tok[len("calls="):])
+        elif low.startswith("uses="):
+            member_edge("type_uses", tok[len("uses="):])
+        elif low.startswith("type="):
+            # the member's own type (field/property type, or method return);
+            # works for primitives too, unlike uses= (type_uses skips them)
+            clause += " AND instr(lower(COALESCE(m.ret,'')),?)>0"
+            cargs.append(tok[len("type="):].lower())
+        elif low.startswith("reaches="):
+            reaches.append(tok[len("reaches="):])
+        else:
+            clause += " AND " + _token_match("m.mods")
+            cargs.append(f" {low} ")
+    clause += ")"
+    return clause, cargs, kind_name, reaches
+
+
+def member_reaches_ok(g, cls_id, kind_name, substrs, depth):
+    """True if `cls_id` contains a member (of kind_name, if given) that reaches
+    every substr in `substrs` via calls within `depth` hops. This is the
+    multi-hop bridge-gadget check, e.g. 'a class with a constructor that reaches
+    BinaryFormatter.Deserialize'."""
+    if "contains" not in g.ekinds:
+        return False
+    q = ("SELECT m.id FROM edges ce JOIN nodes m ON m.id=ce.dst "
+         "JOIN kinds mk ON mk.id=m.kind JOIN ekinds ek ON ek.id=ce.kind "
+         "WHERE ce.src=? AND ek.name='contains'")
+    qargs = [cls_id]
+    if kind_name is not None:
+        q += " AND mk.name=?"
+        qargs.append(kind_name)
+    for (mid,) in g.db.execute(q, qargs):
+        if all(reaches_target(g, mid, s, depth, False) for s in substrs):
+            return True
+    return False
+
+
+def reaches_target(g, start, substr, max_depth, incoming, cap=20000):
+    """True if `start` can reach a node whose lname contains `substr` by
+    following `calls` edges (outgoing if not incoming, else reverse) within
+    `max_depth` hops. Bounded BFS with an early exit on first match; `cap`
+    limits visited nodes so call-graph hubs can't blow up. Used by find's
+    --reaches / --reached-by for source->sink and gadget reachability."""
+    if "calls" not in g.ekinds:
+        return False
+    ek = g.ekinds.index("calls")
+    sub = unescape(substr).lower()
+    col, other = ("dst", "src") if incoming else ("src", "dst")
+    nbr_sql = (f"SELECT e.{other}, t.lname FROM edges e "
+               f"JOIN nodes t ON t.id=e.{other} "
+               f"WHERE e.{col}=? AND e.kind=?")
+    seen = {start}
+    frontier = [start]
+    visited = 0
+    for _ in range(max_depth):
+        nxt = []
+        for cur in frontier:
+            for oid, lname in g.db.execute(nbr_sql, (cur, ek)):
+                if oid in seen:
+                    continue
+                if lname and sub in lname:
+                    return True
+                seen.add(oid)
+                visited += 1
+                if visited > cap:
+                    return False
+                nxt.append(oid)
+        if not nxt:
+            break
+        frontier = nxt
+    return False
+
+
+def cmd_find(g, a):
+    """Find nodes matching a conjunction of structural predicates. All given
+    conditions must hold (AND)."""
+    cond, args = [], []
+    if a.kind:
+        cond.append("n.kind=?")
+        args.append(g.kind_id(a.kind))
+    if a.name:
+        cond.append("instr(n.lname,?)>0")
+        args.append(unescape(a.name).lower())
+    if a.file:
+        cond.append("n.file IN (SELECT id FROM files WHERE instr(lower(path),?)>0)")
+        args.append(a.file.lower())
+    for m in (a.mods.split(",") if a.mods else []):
+        m = m.strip().lower()
+        if m:
+            cond.append(_token_match("n.mods"))
+            args.append(f" {m} ")
+
+    def edge_pred(ekind, substr):
+        cond.append(
+            "EXISTS(SELECT 1 FROM edges e JOIN nodes t ON t.id=e.dst "
+            "JOIN ekinds k ON k.id=e.kind "
+            "WHERE e.src=n.id AND k.name=? AND instr(t.lname,?)>0)")
+        args.extend([ekind, unescape(substr).lower()])
+
+    for s in a.attr:
+        edge_pred("has_attribute", s)
+    for s in a.implements:
+        edge_pred("implements", s)
+    for s in a.inherits:
+        edge_pred("inherits", s)
+    for s in a.uses:
+        edge_pred("type_uses", s)
+    for s in a.overrides:
+        edge_pred("overrides", s)
+    for s in a.calls:
+        edge_pred("calls", s)
+    member_reaches = []  # [(kind_name, [substrs])] for Python post-filter
+    for spec in a.member:
+        clause, cargs, mkind, mreach = member_clause(g, spec)
+        cond.append(clause)
+        args.extend(cargs)
+        if mreach:
+            member_reaches.append((mkind, mreach))
+
+    reaches = getattr(a, "reaches", []) or []
+    reached_by = getattr(a, "reached_by", []) or []
+    if not cond and not (reaches or reached_by):
+        raise SystemExit("error: find needs at least one predicate "
+                         "(--kind/--attr/--member/--implements/--inherits/"
+                         "--uses/--overrides/--calls/--reaches/--reached-by/"
+                         "--mods/--name/--file)")
+
+    if reaches or reached_by or member_reaches:
+        # Reachability is a bounded call-graph BFS done in Python, so we can't
+        # paginate in SQL: fetch all structural candidates, filter by reach,
+        # then page. A structural predicate should narrow the candidates first
+        # (BFS over every node would be wasteful); cap how many we BFS.
+        # Node-level reach only makes sense for nodes that actually have call
+        # edges; pruning the rest (e.g. auto-properties, data fields) both
+        # speeds the BFS and stops dead nodes from eating the candidate cap.
+        # (Not applied for member-level reaches: there the candidate is the
+        # container class, which has no calls of its own.)
+        extra = []
+        if reaches:
+            extra.append("EXISTS(SELECT 1 FROM edges e JOIN ekinds k ON k.id=e.kind "
+                         "WHERE e.src=n.id AND k.name='calls')")
+        if reached_by:
+            extra.append("EXISTS(SELECT 1 FROM edges e JOIN ekinds k ON k.id=e.kind "
+                         "WHERE e.dst=n.id AND k.name='calls')")
+        all_cond = cond + extra
+        where = " AND ".join(all_cond) if all_cond else "1"
+        cand = [r[0] for r in g.db.execute(
+            f"SELECT n.id FROM nodes n WHERE {where} ORDER BY n.id", args).fetchall()]
+        cap = getattr(a, "reach_cap", 6000)
+        capped = len(cand) > cap
+        depth = getattr(a, "reach_depth", 4)
+        kept = []
+        for i in cand[:cap]:
+            if (all(reaches_target(g, i, s, depth, False) for s in reaches)
+                    and all(reaches_target(g, i, s, depth, True) for s in reached_by)
+                    and all(member_reaches_ok(g, i, kn, subs, depth)
+                            for kn, subs in member_reaches)):
+                kept.append(i)
+        total = len(kept)
+        page = kept[a.offset:a.offset + a.limit]
+        if a.json:
+            print(json.dumps({"total": total, "offset": a.offset,
+                              "truncated_candidates": capped,
+                              "items": [g.row_json(i) for i in page]},
+                             separators=(",", ":")))
+            return
+        for i in page:
+            print(g.line(i))
+        if capped:
+            print(f"[only the first {cap} structural candidates were checked for "
+                  f"reachability; add predicates to narrow]")
+        if total > a.offset + len(page):
+            print(f"[{a.offset + len(page)}/{total} shown; next: --offset {a.offset + len(page)}]")
+        elif total == 0:
+            print("no matches")
+        return
+
+    q = (f"SELECT n.id, COUNT(*) OVER () FROM nodes n WHERE {' AND '.join(cond)} "
+         f"ORDER BY n.id LIMIT ? OFFSET ?")
+    rows = g.db.execute(q, args + [a.limit, a.offset]).fetchall()
+    total = rows[0][1] if rows else 0
+    if a.json:
+        print(json.dumps({"total": total, "offset": a.offset,
+                          "items": [g.row_json(i) for i, _ in rows]},
+                         separators=(",", ":")))
+        return
+    for i, _ in rows:
+        print(g.line(i))
+    if total > a.offset + len(rows):
+        print(f"[{a.offset + len(rows)}/{total} shown; next: --offset {a.offset + len(rows)}]")
+    elif total == 0:
+        print("no matches")
+
+
+def container_chain(g, i, max_up=5):
+    """Walk 'contains' edges upwards: [class, module, ...] containing node i."""
+    if "contains" not in g.ekinds:
+        return []
+    ek = g.ekinds.index("contains")
+    chain = []
+    cur = i
+    for _ in range(max_up):
+        up = in_edges(g, cur, ek)
+        if not up:
+            break
+        cur = up[0][0]
+        chain.append(cur)
+    return chain
+
+
+def cmd_node(g, a):
+    i = g.resolve(a.ref)
+    (nid, name, label, kind, path, l1, l2, cc, nbranch,
+     params, ret, throws, doc, mods, synthetic) = g.node(i)
+    deg = {}
+    for d, tbl in (("out", "src"), ("in", "dst")):
+        deg[d] = {g.ekinds[k]: int(s) for k, s in g.db.execute(
+            f"SELECT kind,SUM(n) FROM edges WHERE {tbl}=? GROUP BY kind", (i,))}
+    chain = container_chain(g, i)
+    if a.json:
+        print(json.dumps({
+            "id": nid, "name": name, "label": label, "kind": g.kinds[kind],
+            "file": path, "lines": [l1, l2], "cc": cc, "branches": nbranch,
+            "params": params, "returns": ret, "throws": throws, "doc": doc,
+            "modifiers": mods.split() if mods else [],
+            "synthetic": bool(synthetic),
+            "container": [g.row_json(c) for c in chain],
+            "edges": deg}, separators=(",", ":")))
+        return
+    head = f"#{nid} {g.kinds[kind]} {label}"
+    if mods:
+        head += f"  [{mods}]"
+    if synthetic:
+        head += "  (synthetic)"
+    print(head)
+    if name != label:
+        print(f"id: {name}")
+    if path:
+        loc = f"{path}:{l1}-{l2}" if l1 else path
+        print(f"file: {loc}")
+    if chain:
+        parts = []
+        for c in chain:
+            rj = g.row_json(c)
+            parts.append(f"#{c} {kind_abbrev(rj['kind'])} {rj['label']}")
+        print("container: " + " < ".join(parts))
+    extras = []
+    if cc is not None:
+        extras.append(f"cc={cc}")
+    if nbranch:
+        extras.append(f"branches={nbranch}")
+    if extras:
+        print("  ".join(extras))
+    if params:
+        print(f"params: {params}")
+    if ret:
+        print(f"returns: {ret}")
+    if throws:
+        print(f"throws: {throws}")
+    if doc:
+        d = doc if a.full or len(doc) <= 400 else doc[:400] + f"... (+{len(doc)-400} chars, use --full)"
+        print(f"doc: {d}")
+    fmt = lambda dd: " ".join(f"{k}={v}" for k, v in dd.items()) or "-"
+    print(f"out: {fmt(deg['out'])}   in: {fmt(deg['in'])}")
+
+
+def traverse(g, a, incoming):
+    """Depth-first tree of incoming (callers) or outgoing (callees) edges:
+    each node is printed under the node it was reached from, so a chain reads
+    top-to-bottom as an actual call path. Already-shown nodes get '^' and are
+    not expanded again.
+
+    For callers over call edges, each node's unresolved aliases (ext nodes
+    like 'this.Method' / 'Class.Method') are folded in transparently --
+    in this graph most call edges point at those, not at the method node."""
+    root = g.resolve(a.ref)
+    ek = g.ekind_id(a.kind)
+    calls_ek = g.ekinds.index("calls") if "calls" in g.ekinds else None
+    # Alias folding only makes sense on graphs whose calls are unresolved name
+    # strings; on a resolved graph it would fabricate callers (see G.__init__).
+    use_alias = (incoming and (ek is None or ek == calls_ek)
+                 and g.heuristic_calls)
+    fetch = in_edges if incoming else out_edges
+
+    def fetch_rows(cur):
+        rows = list(fetch(g, cur, ek))
+        if not use_alias:
+            return rows
+        for al in g.aliases(cur):
+            rows += in_edges(g, al, ek)
+        merged = {}  # same caller via several aliases -> one row, summed n
+        for other, k, conf, n in rows:
+            if other in merged:
+                o, k0, c0, n0 = merged[other]
+                merged[other] = (o, k0, c0, n0 + n)
+            else:
+                merged[other] = (other, k, conf, n)
+        return list(merged.values())
+
+    visited = {root}
+    rows = []  # (depth, id, n, conf, again)
+    truncated = False
+
+    def walk(cur, depth):
+        nonlocal truncated
+        if depth >= a.depth or truncated:
+            return
+        for other, _k, conf, n in sorted(fetch_rows(cur),
+                                         key=lambda r: (-r[3], r[0])):
+            if len(rows) >= a.limit:
+                truncated = True
+                return
+            again = other in visited
+            rows.append((depth + 1, other, n, conf, again))
+            if not again:
+                visited.add(other)
+                walk(other, depth + 1)
+
+    walk(root, 0)
+    root_aliases = g.aliases(root) if use_alias else []
+    word = "callers" if incoming else "callees"
+    if a.json:
+        print(json.dumps({
+            "root": root, "direction": "in" if incoming else "out",
+            "kind": a.kind, "truncated": truncated,
+            **({"aliases": root_aliases} if root_aliases else {}),
+            "items": [{**g.row_json(i), "depth": d, "n": n,
+                       "conf": g.confs[conf],
+                       **({"again": True} if again else {})}
+                      for d, i, n, conf, again in rows]},
+            separators=(",", ":")))
+        return
+    suffix = f" [kind={a.kind}]" if a.kind != "calls" else ""
+    if root_aliases:
+        suffix += f" [+{len(root_aliases)} alias targets]"
+    print(f"{word} of {g.line(root)}{suffix}")
+    for d, i, n, conf, again in rows:
+        print("  " * d + g.line(i, g.edge_suffix(n, conf) + (" ^" if again else "")))
+    if truncated:
+        print(f"[truncated at {a.limit}; use --limit]")
+    elif not rows:
+        print("(none)")
+
+
+def cmd_path(g, a):
+    src, dst = g.resolve(a.src), g.resolve(a.dst)
+    ek = g.ekind_id(a.kind)
+    # external nodes (unresolved targets) are hubs that make most paths
+    # meaningless; skip them as intermediates unless --via-ext
+    ext_base = g.meta["nodes"] if not a.via_ext else g.n
+    parent = {src: None}
+    frontier = [src]
+    found = src == dst
+    depth = 0
+    while frontier and not found and depth < a.max_depth:
+        depth += 1
+        nxt = []
+        for cur in frontier:
+            neigh = [r[0] for r in out_edges(g, cur, ek)]
+            if a.undirected:
+                neigh += [r[0] for r in in_edges(g, cur, ek)]
+            for o in neigh:
+                if o in parent:
+                    continue
+                if o >= ext_base and o != dst:
+                    continue
+                parent[o] = cur
+                if o == dst:
+                    found = True
+                    break
+                nxt.append(o)
+            if found:
+                break
+        frontier = nxt
+    if not found:
+        hint = ("; try --undirected" if not a.undirected
+                else "; try --via-ext" if not a.via_ext else "")
+        msg = (f"no path {g.line(src)} -> {g.line(dst)} within depth {a.max_depth} "
+               f"(kind={a.kind}{hint})")
+        if a.json:
+            print(json.dumps({"found": False, "items": []}, separators=(",", ":")))
+        else:
+            print(msg)
+        sys.exit(2)
+    chain = []
+    cur = dst
+    while cur is not None:
+        chain.append(cur)
+        cur = parent[cur]
+    chain.reverse()
+    if a.json:
+        print(json.dumps({"found": True,
+                          "items": [g.row_json(i) for i in chain]},
+                         separators=(",", ":")))
+        return
+    print(g.line(chain[0]))
+    for i in chain[1:]:
+        print("-> " + g.line(i))
+    print(f"({len(chain) - 1} hops)")
+
+
+def cmd_sql(g, a):
+    q = a.query.strip().rstrip(";")
+    if not q.lower().startswith(("select", "with", "explain")):
+        raise SystemExit("error: only read-only SELECT/WITH/EXPLAIN queries are allowed")
+    try:
+        cur = g.db.execute(q)
+    except sqlite3.Error as e:
+        raise SystemExit(f"sql error: {e}")
+    cols = [d[0] for d in (cur.description or [])]
+    rows = cur.fetchmany(a.limit)
+    truncated = len(rows) == a.limit and cur.fetchone() is not None
+    if a.json:
+        print(json.dumps({"columns": cols, "rows": rows, "truncated": truncated},
+                         default=str, separators=(",", ":")))
+        return
+    if cols:
+        print("\t".join(cols))
+    for r in rows:
+        print("\t".join("" if v is None else str(v) for v in r))
+    if truncated:
+        print(f"[truncated at {a.limit}; refine the query or raise --limit]")
+
+
+# ---------------------------------------------------------------------------
+# wiring
+
+
+def find_graph(opt):
+    cands = []
+    if opt:
+        cands.append(opt)
+    envp = os.environ.get("CODEGRAPH_GRAPH")
+    if envp:
+        cands.append(envp)
+    here = os.path.dirname(os.path.abspath(__file__))
+    cands += [os.path.join(here, "mygraph.json"), "mygraph.json"]
+    for c in cands:
+        if os.path.isfile(c):
+            return os.path.abspath(c)
+    raise SystemExit("error: graph JSON not found (use --graph <path> or CODEGRAPH_GRAPH)")
+
+
+def ensure_index(graph, db_path, force=False):
+    if not force and os.path.exists(db_path):
+        try:
+            db = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+            meta = {k: json.loads(v) for k, v in db.execute("SELECT k,v FROM meta")}
+            db.close()
+            st = os.stat(graph)
+            if (meta.get("version") == INDEX_VERSION
+                    and meta.get("source_size") == st.st_size
+                    and meta.get("source_mtime") == int(st.st_mtime)):
+                return
+            err("index is stale (graph changed); rebuilding...")
+        except sqlite3.Error:
+            err("index unreadable; rebuilding...")
+    else:
+        if not force:
+            err("no index yet; building one-time index (this can take a few minutes)...")
+    build_index(graph, db_path)
+
+
+EPILOG = """\
+refs:    #123 / 123 (node number, shown in all output) | full id | unique substring
+output:  "#id kind label  file:line"; x3 = edge seen 3 times;
+         ~ = inferred (not certain); ^ = already shown above (cycle/repeat)
+kinds:   fn=method/function cls=class mod=module ns=namespace ext=external;
+         C# graphs also: ctor=constructor prop=property fld=field evt=event
+         op=operator del=delegate ifc=interface str=struct enum enumv=enum-member
+exit:    0 ok, 2 not-found/ambiguous (candidates on stderr)
+recipes:
+  find a node:               search <name> --kind fn        -> pick its #id
+  where is it called from:   callers <id> --depth 3         (tree toward origins)
+  what does it call:         callees <id> --depth 2         (tree toward targets)
+  what contains it:          node <id>                      (container: line)
+  members of class/module:   callees <id> --kind contains
+  call chain between two:    path <a> <b>
+  find a pattern:            find --kind class --attr serializable \\
+                                  --member "constructor:public,params=0" \\
+                                  --member "property:public,get,set"
+  anything else:             sql "select ..."               (schema in README)
+agent integration: run `codegraph mcp` as an MCP stdio server, or shell out per query
+"""
+
+# ---------------------------------------------------------------------------
+# MCP stdio server (JSON-RPC 2.0, newline-delimited; no dependencies)
+
+SQL_SCHEMA_DOC = (
+    "Tables: nodes(id,name,label,lname,kind,file,line1,line2,cc,nbranch,params,"
+    "ret,throws,doc,mods,synthetic), edges(src,dst,kind,conf,n), files(id,path), "
+    "kinds(id,name), ekinds(id,name), confs(id,name), meta(k,v). Joins: "
+    "nodes.kind->kinds.id, nodes.file->files.id, edges.src/dst->nodes.id, "
+    "edges.kind->ekinds.id, edges.conf->confs.id. lname = lowercased unescaped "
+    "node id (for matching); n = how many times the edge appeared in the source "
+    "graph; mods = space-joined modifiers e.g. 'public get set' (NULL if the "
+    "graph has none - match with mods LIKE '%set%'); synthetic = 1 for "
+    "compiler-generated members.")
+
+MCP_INSTRUCTIONS = (
+    "Query tool for a large code graph (call/containment/inheritance edges). "
+    "Nodes are referenced by short #id handles returned in every result - "
+    "always prefer them over full node ids. To trace where something is "
+    "called from use graph_callers with depth 2-3 (tree toward origins); to "
+    "trace what it calls use graph_callees (tree toward targets); "
+    "graph_path finds the chain between two nodes. graph_node shows details "
+    "plus its containing class/module; kind=contains on callers/callees "
+    "navigates structure (members / containers). 'n' or x-counts mean the "
+    "edge appeared multiple times; conf 'inferred' means uncertain; 'again' "
+    "or ^ marks a node already shown (cycle). graph_sql accepts read-only "
+    "SELECT for anything the other tools don't cover.")
+
+_REF_DESC = "node reference: #id (preferred), full node id, or unique substring"
+
+# (tool name, cli command, description, [(positional, desc)], [(option, type, desc)])
+MCP_TOOLS = [
+    ("graph_stats", "stats",
+     "Overview of the code graph: node/edge counts by kind, files, dependencies.",
+     [], []),
+    ("graph_search", "search",
+     "Find nodes by case-insensitive substring of their id/name. Returns short "
+     "#id handles used by every other tool.",
+     [("text", "substring to search for")],
+     [("kind", str, "node kind filter, e.g. method/class/module/external"),
+      ("file", str, "only nodes whose file path contains this"),
+      ("limit", int, "max results (default 20)"),
+      ("offset", int, "pagination offset")]),
+    ("graph_find", "find",
+     "Find nodes matching a CONJUNCTION of structural patterns (all conditions "
+     "must hold). Use for code-review / security questions like 'classes that "
+     "are [Serializable] with a public parameterless constructor and public "
+     "read/write properties'. member spec = 'kind[:mod,mod,params=0|+]', e.g. "
+     "'constructor:public,params=0' or 'property:public,get,set'. Best on a "
+     "resolved graph (csgraph / cecil).",
+     [],
+     [("kind", str, "node kind (class/method/property/...)"),
+      ("name", str, "node id/name contains this substring"),
+      ("file", str, "defined in a file whose path contains this"),
+      ("mods", str, "comma-separated modifiers the node must have"),
+      ("attr", list, "has an attribute whose name contains this (array)"),
+      ("implements", list, "implements an interface matching this (array)"),
+      ("inherits", list, "inherits a base matching this (array)"),
+      ("uses", list, "references a type matching this in its signature "
+                     "(type_uses; array)"),
+      ("overrides", list, "overrides a member matching this (array)"),
+      ("calls", list, "has an outgoing call to a target matching this (array)"),
+      ("member", list, "contains a matching member; spec 'kind[:mod,mod,"
+                       "params=0|+,type=substr,calls=substr,uses=substr,"
+                       "reaches=substr]' (array). e.g. 'method:calls=invoke' "
+                       "(ObjectDataProvider shape), 'field:type=DataSet', "
+                       "'constructor:reaches=binaryformatter.deserialize' "
+                       "(bridge gadget)"),
+      ("reaches", list, "can reach a target matching this via calls within "
+                        "reach_depth hops - transitive; for source->sink and "
+                        "multi-hop bridge gadgets, e.g. a ctor that reaches "
+                        "binaryformatter.deserialize (array)"),
+      ("reached_by", list, "is reachable FROM a source matching this via calls "
+                           "(reverse reachability; array)"),
+      ("reach_depth", int, "max hops for reaches/reached_by (default 4)"),
+      ("limit", int, "max results (default 30)"),
+      ("offset", int, "pagination offset")]),
+    ("graph_node", "node",
+     "Full details for one node: full id, file:lines, containing class/module "
+     "chain, complexity, params, return type, throws, docstring, edge counts "
+     "by kind.",
+     [("ref", _REF_DESC)],
+     [("full", bool, "do not truncate the docstring")]),
+    ("graph_callers", "callers",
+     "Trace incoming edges toward origins (tree). With kind=calls: who calls "
+     "it. kind=inherits: subclasses (who extends it). kind=implements: "
+     "implementers. kind=type_uses: who references the type in a signature "
+     "(field/property/param) - i.e. who USES it. kind=overrides: who overrides "
+     "it. kind=contains: its container. Key for gadget/sink analysis.",
+     [("ref", _REF_DESC)],
+     [("depth", int, "tree depth (default 1; use 2-5 to trace transitively)"),
+      ("kind", str, "edge kind: calls (default), inherits, implements, "
+                    "type_uses, overrides, contains, any"),
+      ("limit", int, "max rows (default 30)")]),
+    ("graph_callees", "callees",
+     "Trace outgoing edges toward targets (tree). With kind=calls: what it "
+     "calls (toward sinks). kind=contains: its members (methods/props of a "
+     "class). kind=inherits/implements: its base types/interfaces.",
+     [("ref", _REF_DESC)],
+     [("depth", int, "tree depth (default 1)"),
+      ("kind", str, "edge kind: calls (default), contains, inherits, "
+                    "implements, type_uses, overrides, any"),
+      ("limit", int, "max rows (default 30)")]),
+    ("graph_path", "path", "Shortest path between two nodes over graph edges.",
+     [("src", _REF_DESC), ("dst", _REF_DESC)],
+     [("kind", str, "edge kind to traverse (default calls)"),
+      ("undirected", bool, "also traverse edges backwards"),
+      ("via_ext", bool, "allow paths through external (unresolved) hub nodes"),
+      ("max_depth", int, "BFS depth limit (default 15)")]),
+    ("graph_sql", "sql",
+     "Run a read-only SQL SELECT against the index for anything the other "
+     "tools don't cover. " + SQL_SCHEMA_DOC,
+     [("query", "a single SELECT/WITH statement")],
+     [("limit", int, "max rows (default 50)")]),
+]
+
+
+def _mcp_tool_defs():
+    defs = []
+    for name, _cmd, desc, pos, opts in MCP_TOOLS:
+        props = {p: {"type": "string", "description": d} for p, d in pos}
+        for o, typ, d in opts:
+            if typ is list:  # array-of-string option (repeatable CLI flag)
+                props[o] = {"type": "array", "items": {"type": "string"},
+                            "description": d}
+            else:
+                t = "integer" if typ is int else "boolean" if typ is bool else "string"
+                props[o] = {"type": t, "description": d}
+        defs.append({"name": name, "description": desc,
+                     "inputSchema": {"type": "object", "properties": props,
+                                     "required": [p for p, _ in pos]}})
+    return defs
+
+
+def _mcp_call_tool(name, arguments, graph):
+    """Run one tool by reusing the CLI entry point with --json. Returns
+    (result text, isError)."""
+    spec = next((t for t in MCP_TOOLS if t[0] == name), None)
+    if spec is None:
+        return f"unknown tool: {name}", True
+    _, cmd, _, pos, opts = spec
+    argv = [cmd]
+    for p, _ in pos:
+        if p not in arguments:
+            return f"missing required argument: {p}", True
+        argv.append(str(arguments[p]))
+    for o, typ, _ in opts:
+        v = arguments.get(o)
+        if v is None:
+            continue
+        flag = "--" + o.replace("_", "-")
+        if typ is bool:
+            if v:
+                argv.append(flag)
+        elif typ is list:  # emit the flag once per item
+            for item in (v if isinstance(v, list) else [v]):
+                argv += [flag, str(item)]
+        else:
+            argv += [flag, str(v)]
+    argv += ["--graph", graph, "--json"]
+    out, errbuf = io.StringIO(), io.StringIO()
+    code = 0
+    try:
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(errbuf):
+            main(argv)
+    except SystemExit as e:
+        if isinstance(e.code, int):
+            code = e.code or 0
+        else:
+            code = 1
+            if e.code:
+                errbuf.write(str(e.code))
+    except Exception as e:  # surface tool failures to the client, don't die
+        return f"error: {e}", True
+    text = out.getvalue().strip()
+    if code:
+        emsg = errbuf.getvalue().strip()
+        text = (text + ("\n" if text and emsg else "") + emsg) or f"exit code {code}"
+    # exit 2 = not-found/ambiguous: useful feedback for the model, not a failure
+    return text, code not in (0, 2)
+
+
+def run_mcp(graph):
+    def send(obj):
+        sys.stdout.write(json.dumps(obj, separators=(",", ":")) + "\n")
+        sys.stdout.flush()
+
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+        except ValueError:
+            continue
+        mid = msg.get("id")
+        method = msg.get("method")
+        if method == "initialize":
+            pv = (msg.get("params") or {}).get("protocolVersion") or "2024-11-05"
+            send({"jsonrpc": "2.0", "id": mid, "result": {
+                "protocolVersion": pv,
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "codegraph", "version": "1.0.0"},
+                "instructions": MCP_INSTRUCTIONS}})
+        elif method == "ping":
+            send({"jsonrpc": "2.0", "id": mid, "result": {}})
+        elif method == "tools/list":
+            send({"jsonrpc": "2.0", "id": mid,
+                  "result": {"tools": _mcp_tool_defs()}})
+        elif method == "tools/call":
+            p = msg.get("params") or {}
+            text, is_err = _mcp_call_tool(p.get("name"), p.get("arguments") or {},
+                                          graph)
+            send({"jsonrpc": "2.0", "id": mid, "result": {
+                "content": [{"type": "text", "text": text}],
+                "isError": is_err}})
+        elif mid is not None:  # unknown request (notifications are just ignored)
+            send({"jsonrpc": "2.0", "id": mid, "error": {
+                "code": -32601, "message": f"method not found: {method}"}})
+    return 0
+
+
+def main(argv=None):
+    reconfigure = getattr(sys.stdout, "reconfigure", None)
+    if reconfigure is not None:
+        with contextlib.suppress(Exception):
+            reconfigure(encoding="utf-8", errors="replace")
+    p = argparse.ArgumentParser(
+        prog="codegraph",
+        description="query a large code-graph JSON via a compact SQLite index "
+                    "(token-efficient output for AI agents)",
+        epilog=EPILOG, formatter_class=argparse.RawDescriptionHelpFormatter)
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument("--graph", help="path to graph JSON (default: mygraph.json "
+                                        "next to this script, or $CODEGRAPH_GRAPH)")
+    common.add_argument("--json", action="store_true", help="machine-readable output")
+    sub = p.add_subparsers(dest="cmd", metavar="command")
+
+    sp = sub.add_parser("index", parents=[common], help="(re)build the index")
+    sp.add_argument("--force", action="store_true")
+
+    sub.add_parser("stats", parents=[common], help="graph overview")
+
+    sp = sub.add_parser("search", parents=[common],
+                        help="find nodes by substring (case-insensitive)")
+    sp.add_argument("text")
+    sp.add_argument("--kind")
+    sp.add_argument("--file", help="only nodes in files whose path contains this")
+    sp.add_argument("--limit", "-n", type=int, default=20)
+    sp.add_argument("--offset", type=int, default=0)
+
+    sp = sub.add_parser("node", parents=[common], help="full details for one node")
+    sp.add_argument("ref")
+    sp.add_argument("--full", action="store_true", help="don't truncate docstring")
+
+    sp = sub.add_parser(
+        "find", parents=[common],
+        help="find nodes matching a conjunction of patterns",
+        description="Find nodes where ALL given predicates hold. Repeatable "
+                    "flags add more conditions.",
+        epilog="example: find --kind class --attr serializable "
+               "--member \"constructor:public,params=0\" "
+               "--member \"property:public,get,set\"",
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    sp.add_argument("--kind", help="node kind (class/method/property/...)")
+    sp.add_argument("--name", help="node id/name contains this substring")
+    sp.add_argument("--file", help="defined in a file whose path contains this")
+    sp.add_argument("--mods", help="comma-separated modifiers the node must have "
+                                   "(e.g. public,abstract)")
+    sp.add_argument("--attr", action="append", default=[], metavar="SUBSTR",
+                    help="has an attribute whose name contains SUBSTR (repeatable)")
+    sp.add_argument("--implements", action="append", default=[], metavar="SUBSTR",
+                    help="implements an interface matching SUBSTR (repeatable)")
+    sp.add_argument("--inherits", action="append", default=[], metavar="SUBSTR",
+                    help="inherits a base matching SUBSTR (repeatable)")
+    sp.add_argument("--uses", action="append", default=[], metavar="SUBSTR",
+                    help="references a type matching SUBSTR in its signature "
+                         "(type_uses; repeatable)")
+    sp.add_argument("--overrides", action="append", default=[], metavar="SUBSTR",
+                    help="overrides a member matching SUBSTR (repeatable)")
+    sp.add_argument("--calls", action="append", default=[], metavar="SUBSTR",
+                    help="has an outgoing call to a target matching SUBSTR (repeatable)")
+    sp.add_argument("--member", action="append", default=[], metavar="SPEC",
+                    help="contains a member: 'kind[:mod,mod,params=0|+,"
+                         "type=substr,calls=substr,uses=substr,reaches=substr]' "
+                         "(repeatable), e.g. 'property:public,get,set', "
+                         "'field:type=DataSet', 'method:calls=invoke', "
+                         "'constructor:reaches=binaryformatter.deserialize'")
+    sp.add_argument("--reaches", action="append", default=[], metavar="SUBSTR",
+                    help="can reach a target matching SUBSTR via calls within "
+                         "--reach-depth hops (transitive; for source->sink & "
+                         "multi-hop gadgets). Repeatable.")
+    sp.add_argument("--reached-by", action="append", default=[], metavar="SUBSTR",
+                    help="is reachable FROM a source matching SUBSTR via calls "
+                         "(reverse reachability). Repeatable.")
+    sp.add_argument("--reach-depth", type=int, default=4,
+                    help="max hops for --reaches/--reached-by (default 4)")
+    sp.add_argument("--limit", "-n", type=int, default=30)
+    sp.add_argument("--offset", type=int, default=0)
+
+    for name, hlp in (("callers", "tree of who calls it (toward origins)"),
+                      ("callees", "tree of what it calls (toward targets)")):
+        sp = sub.add_parser(name, parents=[common], help=hlp)
+        sp.add_argument("ref")
+        sp.add_argument("--depth", type=int, default=1)
+        sp.add_argument("--kind", default="calls",
+                        help="edge kind (default calls; contains/inherits/"
+                             "implements/any)")
+        sp.add_argument("--limit", "-n", type=int, default=30)
+
+    sp = sub.add_parser("path", parents=[common], help="shortest path between nodes")
+    sp.add_argument("src")
+    sp.add_argument("dst")
+    sp.add_argument("--kind", default="calls")
+    sp.add_argument("--undirected", action="store_true")
+    sp.add_argument("--via-ext", action="store_true",
+                    help="allow paths through external (unresolved) hub nodes")
+    sp.add_argument("--max-depth", type=int, default=15)
+
+    sp = sub.add_parser("sql", parents=[common],
+                        help="read-only SQL SELECT against the index")
+    sp.add_argument("query")
+    sp.add_argument("--limit", "-n", type=int, default=50)
+
+    sub.add_parser("mcp", parents=[common],
+                   help="run as an MCP stdio server for AI agents")
+
+    a = p.parse_args(argv)
+    if not a.cmd:
+        p.print_help()
+        return 0
+
+    graph = find_graph(a.graph)
+    db_path = graph + ".idx.sqlite"
+    if a.cmd == "index":
+        build_index(graph, db_path)
+        return 0
+    ensure_index(graph, db_path)
+    if a.cmd == "mcp":
+        return run_mcp(graph)
+    g = G(db_path)
+    try:
+        {
+            "stats": cmd_stats,
+            "search": cmd_search,
+            "find": cmd_find,
+            "node": cmd_node,
+            "callers": lambda g, a: traverse(g, a, True),
+            "callees": lambda g, a: traverse(g, a, False),
+            "path": cmd_path,
+            "sql": cmd_sql,
+        }[a.cmd](g, a)
+    finally:
+        g.db.close()
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        sys.exit(130)
+    except BrokenPipeError:
+        sys.exit(0)

--- a/tools/codegraph/pytest.ini
+++ b/tools/codegraph/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+addopts = -q

--- a/tools/codegraph/tests/conftest.py
+++ b/tools/codegraph/tests/conftest.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2026 Soroush Dalili
+# SPDX-License-Identifier: MIT
+
+"""Shared fixtures: a tiny synthetic graph that mirrors the real file's quirks
+(UTF-16 BOM, escaped dots in ids, dict-shaped fields, duplicate edges,
+unresolved external targets)."""
+
+import contextlib
+import io
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import codegraph  # noqa: E402
+
+# actual ids contain backslash-escaped dots, like the real graph
+MOD = "app\\.dll.App.Mod"
+CLS = MOD + ":Cls"
+RUN = MOD + ":Cls.Run"
+HELPER = MOD + ":Cls.Helper"
+LONELY = MOD + ":Cls.Lonely"
+EXT_CALL = "this.Ext.Call"
+EXT_BASE = "System.Object"
+THIS_RUN = "this.Run"  # unresolved alias for RUN, as the real graph records calls
+
+# expected node numbering: nodes in insertion order, externals appended
+# during the edge pass in edge order
+ID = {MOD: 0, CLS: 1, RUN: 2, HELPER: 3, LONELY: 4, EXT_CALL: 5, EXT_BASE: 6,
+      THIS_RUN: 7}
+
+
+def _node(nid, kind, file, l1, l2, params=None, ret=None, exc=None, cc=None,
+          branches=None, doc=None):
+    return {
+        "id": nid, "name": nid, "kind": kind,
+        "location": {"file_path": file, "start_line": l1, "end_line": l2,
+                     "start_col": 0, "end_col": 0},
+        "parameters": params or [],
+        "return_type": ret,
+        "exception_types": exc or [],
+        "cyclomatic_complexity": cc,
+        "branches": branches or [],
+        "docstring": doc,
+    }
+
+
+def _edge(s, t, k, c):
+    return {"source": s, "target": t, "kind": k, "confidence": c}
+
+
+def tiny_graph():
+    nodes = {
+        MOD: _node(MOD, "module", "./src/mod.cs", 1, 100),
+        CLS: _node(CLS, "class", "./src/mod.cs", 5, 90),
+        # dict-shaped return_type and mixed params, like the real polyglot graph
+        RUN: _node(RUN, "method", "./src/mod.cs", 10, 40,
+                   params=[{"name": "x", "type": "int"}, "y"],
+                   ret={"name": "void"}, exc=["E1", "E2"], cc=5,
+                   branches=[1, 2, 3], doc="D" * 450),
+        HELPER: _node(HELPER, "method", "./src/mod.cs", 45, 60, cc=2),
+        LONELY: _node(LONELY, "method", "./src/other.cs", 1, 5),
+    }
+    edges = [
+        _edge(MOD, CLS, "contains", "certain"),
+        _edge(CLS, RUN, "contains", "certain"),
+        _edge(CLS, HELPER, "contains", "certain"),
+        _edge(CLS, LONELY, "contains", "certain"),
+        _edge(RUN, HELPER, "calls", "inferred"),
+        _edge(RUN, HELPER, "calls", "inferred"),  # duplicate -> x2
+        _edge(RUN, EXT_CALL, "calls", "inferred"),  # unresolved -> ext node
+        _edge(HELPER, LONELY, "calls", "certain"),
+        _edge(LONELY, RUN, "calls", "certain"),  # cycle Run->Helper->Lonely->Run
+        _edge(CLS, EXT_BASE, "inherits", "certain"),
+        # call recorded against the unresolved 'this.Run' string, not the node
+        _edge(HELPER, THIS_RUN, "calls", "inferred"),
+    ]
+    return {
+        "language": "polyglot",
+        "root_path": "C:\\src",
+        "summary": {"total_nodes": 5, "functions": 3, "classes": 1,
+                    "call_edges": 6, "dependencies": ["System", "App"],
+                    "entrypoints": 1},
+        "nodes": nodes,
+        "edges": edges,
+        "subgraphs": {},
+    }
+
+
+def write_graph(path, data=None):
+    text = json.dumps(data if data is not None else tiny_graph())
+    path.write_bytes(b"\xff\xfe" + text.encode("utf-16-le"))
+
+
+@pytest.fixture(scope="session")
+def graph_file(tmp_path_factory):
+    p = tmp_path_factory.mktemp("graph") / "tiny.json"
+    write_graph(p)
+    codegraph.build_index(str(p), str(p) + ".idx.sqlite", quiet=True)
+    return str(p)
+
+
+def run_cli(graph, *args):
+    """Run a codegraph command in-process; returns (stdout, stderr, exit_code)."""
+    out, errbuf = io.StringIO(), io.StringIO()
+    code = 0
+    try:
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(errbuf):
+            codegraph.main(list(args) + ["--graph", graph])
+    except SystemExit as e:
+        if isinstance(e.code, int):
+            code = e.code or 0
+        else:
+            code = 1
+            errbuf.write(str(e.code) + "\n")
+    return out.getvalue(), errbuf.getvalue(), code
+
+
+@pytest.fixture
+def cli(graph_file):
+    def run(*args):
+        return run_cli(graph_file, *args)
+    return run

--- a/tools/codegraph/tests/test_cli.py
+++ b/tools/codegraph/tests/test_cli.py
@@ -1,0 +1,324 @@
+# Copyright (c) 2026 Soroush Dalili
+# SPDX-License-Identifier: MIT
+
+"""End-to-end tests for every CLI command against the tiny fixture graph.
+
+Fixture topology (see conftest):
+  #0 Mod (module) -contains-> #1 Cls (class) -contains-> #2 Run, #3 Helper, #4 Lonely
+  #2 Run -calls(x2,inferred)-> #3 Helper, -calls(inferred)-> #5 this.Ext.Call (ext)
+  #3 Helper -calls(certain)-> #4 Lonely -calls(certain)-> #2 Run   (cycle)
+  #3 Helper -calls(inferred)-> #7 this.Run (ext alias of #2)
+  #1 Cls -inherits-> #6 System.Object (ext)
+"""
+
+import json
+import os
+import time
+
+import conftest
+import codegraph
+from conftest import ID, RUN, run_cli, write_graph
+
+
+def j(out):
+    return json.loads(out)
+
+
+# --- stats -------------------------------------------------------------------
+
+def test_stats_text(cli):
+    out, _, code = cli("stats")
+    assert code == 0
+    assert "nodes: 5 (+3 external targets)" in out
+    assert "edges: 11 raw -> 10 unique" in out
+    assert "calls: 6 (5 unique)" in out
+    assert "contains: 4 (4 unique)" in out
+    assert "inherits: 1 (1 unique)" in out
+
+
+def test_stats_json(cli):
+    out, _, _ = cli("stats", "--json")
+    m = j(out)
+    assert m["nodes"] == 5 and m["externals"] == 3
+    assert m["raw_edges"] == 11 and m["unique_edges"] == 10
+    assert m["language"] == "polyglot"
+    assert m["node_kinds"]["method"] == 3
+    assert m["edge_kinds"]["calls"] == {"unique": 5, "raw": 6}
+
+
+# --- search ------------------------------------------------------------------
+
+def test_search_basic(cli):
+    out, _, _ = cli("search", "cls.run", "--json")
+    r = j(out)
+    assert r["total"] == 1
+    assert r["items"][0] == {"id": ID[RUN], "kind": "method", "label": "Cls.Run",
+                             "file": "./src/mod.cs", "line": 10}
+
+
+def test_search_unescaped_dots(cli):
+    # user types real dots; ids store escaped '\.' -- search must still match
+    out, _, _ = cli("search", "app.dll", "--json")
+    assert j(out)["total"] == 5
+
+
+def test_search_kind_filter(cli):
+    out, _, _ = cli("search", "app", "--kind", "cls", "--json")
+    assert [i["id"] for i in j(out)["items"]] == [1]
+    out, _, _ = cli("search", "app", "--kind", "method", "--json")
+    assert j(out)["total"] == 3
+
+
+def test_search_file_filter(cli):
+    out, _, _ = cli("search", "app", "--file", "other.cs", "--json")
+    assert [i["id"] for i in j(out)["items"]] == [4]
+
+
+def test_search_pagination(cli):
+    out, _, _ = cli("search", "app", "-n", "2")
+    assert "[2/5 shown; next: --offset 2]" in out
+    out, _, _ = cli("search", "app", "-n", "2", "--offset", "4", "--json")
+    r = j(out)
+    assert r["total"] == 5 and len(r["items"]) == 1
+
+
+def test_search_no_match(cli):
+    out, _, _ = cli("search", "zzznope")
+    assert "no matches" in out
+
+
+# --- node + ref resolution ---------------------------------------------------
+
+def test_node_details_json(cli):
+    out, _, _ = cli("node", "#2", "--json")
+    n = j(out)
+    assert n["name"] == RUN and n["label"] == "Cls.Run"
+    assert n["params"] == "int x; y"          # dict + str params
+    assert n["returns"] == "void"             # dict-shaped return_type
+    assert n["throws"] == "E1, E2"
+    assert n["cc"] == 5 and n["branches"] == 3
+    assert n["lines"] == [10, 40]
+    assert [c["id"] for c in n["container"]] == [1, 0]
+    assert n["edges"] == {"out": {"calls": 3},
+                          "in": {"contains": 1, "calls": 1}}
+
+
+def test_node_container_chain_text(cli):
+    out, _, _ = cli("node", "2")
+    assert "container: #1 cls Cls < #0 mod Mod" in out
+    # the top-level module has no container line
+    out, _, _ = cli("node", "0")
+    assert "container:" not in out
+
+
+def test_node_doc_truncation(cli):
+    out, _, _ = cli("node", "2")
+    assert "(+50 chars, use --full)" in out
+    out, _, _ = cli("node", "2", "--full")
+    assert "D" * 450 in out
+
+
+def test_resolve_by_full_id_and_label(cli):
+    out, _, _ = cli("node", RUN, "--json")
+    assert j(out)["id"] == 2
+    # exact label match wins even when the substring would be ambiguous
+    out, _, _ = cli("node", "cls", "--json")
+    assert j(out)["id"] == 1
+
+
+def test_resolve_ambiguous(cli):
+    out, err, code = cli("node", "app")
+    assert code == 2
+    assert "ambiguous" in err and "#0" in err
+
+
+def test_resolve_no_match(cli):
+    _, err, code = cli("node", "zzznope")
+    assert code == 2 and "no node matches" in err
+
+
+def test_resolve_out_of_range(cli):
+    _, err, code = cli("node", "#999")
+    assert code != 0
+
+
+# --- callers / callees (tracing) -------------------------------------------
+
+def test_callers_single_level(cli):
+    out, _, _ = cli("callers", "3", "--json")
+    r = j(out)
+    assert [i["id"] for i in r["items"]] == [2]
+    assert r["items"][0]["n"] == 2 and r["items"][0]["conf"] == "inferred"
+
+
+def test_callers_includes_unresolved_aliases(cli):
+    # Helper calls 'this.Run' (ext #7), not node #2 directly -- callers of
+    # Run must still surface Helper, with the alias noted
+    out, _, _ = cli("callers", "2", "--json")
+    r = j(out)
+    assert r["aliases"] == [7]
+    assert {i["id"] for i in r["items"]} == {3, 4}
+    out, _, _ = cli("callers", "2")
+    assert "[+1 alias targets]" in out and "#3 " in out
+
+
+def test_resolved_graph_disables_alias_folding(tmp_path):
+    # A graph whose maker marks calls as resolved (summary.resolved_calls=1)
+    # must NOT fold name-based aliases - doing so on the unresolved fixture is
+    # correct, but on a resolved graph it would fabricate callers. Here Helper
+    # calls the alias 'this.Run' (#7), not node #2; with folding off, the only
+    # caller of #2 is the real Lonely->Run edge (#4).
+    data = conftest.tiny_graph()
+    data["summary"]["resolved_calls"] = 1
+    p = tmp_path / "resolved.json"
+    conftest.write_graph(p, data)
+    codegraph.build_index(str(p), str(p) + ".idx.sqlite", quiet=True)
+    out, _, _ = run_cli(str(p), "callers", "2", "--json")
+    r = j(out)
+    assert "aliases" not in r
+    assert {i["id"] for i in r["items"]} == {4}
+    out, _, _ = run_cli(str(p), "callers", "2")
+    assert "alias targets" not in out
+
+
+def test_callers_trace_to_origin(cli):
+    # full upstream trace of Run: Helper (via this.Run alias) and Lonely,
+    # each expanded under its own chain; revisits marked, not expanded
+    out, _, _ = cli("callers", "2", "--depth", "3", "--json")
+    items = j(out)["items"]
+    assert [(i["id"], i["depth"], i.get("again", False)) for i in items] == [
+        (3, 1, False), (2, 2, True), (4, 1, False), (3, 2, True)]
+
+
+def test_callees_tree_structure(cli):
+    out, _, _ = cli("callees", "2", "--depth", "3", "--json")
+    items = j(out)["items"]
+    # DFS: Helper subtree (Lonely -> Run cycle, then its this.Run target)
+    # fully expanded before the ext sibling
+    assert [(i["id"], i["depth"], i.get("again", False)) for i in items] == [
+        (3, 1, False), (4, 2, False), (2, 3, True), (7, 2, False),
+        (5, 1, False)]
+
+
+def test_callees_text_tree(cli):
+    out, _, _ = cli("callees", "2", "--depth", "3")
+    lines = out.splitlines()
+    assert lines[0].startswith("callees of #2 fn Cls.Run")
+    assert lines[1].startswith("  #3 ") and " x2 ~" in lines[1]
+    assert lines[2].startswith("    #4 ")        # nested under its caller
+    assert lines[3].startswith("      #2 ") and lines[3].endswith("^")  # cycle
+    assert lines[4].startswith("    #7 ")        # Helper's unresolved target
+    assert lines[5].startswith("  #5 ")
+
+
+def test_traverse_limit(cli):
+    out, _, _ = cli("callees", "2", "-n", "1")
+    assert "[truncated at 1" in out
+
+
+def test_members_via_contains(cli):
+    # members of a class = callees --kind contains
+    out, _, _ = cli("callees", "1", "--kind", "contains", "--json")
+    assert [i["id"] for i in j(out)["items"]] == [2, 3, 4]
+
+
+def test_container_via_contains(cli):
+    out, _, _ = cli("callers", "2", "--kind", "contains", "--json")
+    assert [i["id"] for i in j(out)["items"]] == [1]
+
+
+def test_traverse_none(cli):
+    out, _, _ = cli("callees", "4", "--kind", "inherits")
+    assert "(none)" in out
+
+
+# --- path ----------------------------------------------------------------
+
+def test_path_directed(cli):
+    out, _, _ = cli("path", "2", "4", "--json")
+    r = j(out)
+    assert r["found"] and [i["id"] for i in r["items"]] == [2, 3, 4]
+
+
+def test_path_uses_cycle_edge(cli):
+    out, _, _ = cli("path", "4", "3", "--json")
+    assert [i["id"] for i in j(out)["items"]] == [4, 2, 3]
+
+
+def test_path_not_found_and_hint(cli):
+    out, _, code = cli("path", "0", "4")
+    assert code == 2 and "try --undirected" in out
+
+
+def test_path_undirected(cli):
+    out, _, _ = cli("path", "4", "0", "--kind", "contains", "--undirected",
+                    "--json")
+    assert [i["id"] for i in j(out)["items"]] == [4, 1, 0]
+
+
+def test_path_ext_destination_allowed(cli):
+    out, _, _ = cli("path", "2", "5", "--json")
+    assert [i["id"] for i in j(out)["items"]] == [2, 5]
+
+
+def test_path_other_edge_kinds(cli):
+    out, _, _ = cli("path", "0", "2", "--kind", "contains", "--json")
+    assert [i["id"] for i in j(out)["items"]] == [0, 1, 2]
+    out, _, _ = cli("path", "1", "6", "--kind", "inherits", "--json")
+    assert [i["id"] for i in j(out)["items"]] == [1, 6]
+
+
+# --- sql -----------------------------------------------------------------
+
+def test_sql_select(cli):
+    out, _, _ = cli("sql", "select count(*) as c from nodes", "--json")
+    r = j(out)
+    assert r["columns"] == ["c"] and r["rows"][0][0] == 8
+
+
+def test_sql_join(cli):
+    out, _, _ = cli("sql",
+                    "select k.name, count(*) c from nodes n "
+                    "join kinds k on k.id=n.kind group by 1 order by 2 desc")
+    assert "method\t3" in out
+
+
+def test_sql_rejects_writes(cli):
+    _, err, code = cli("sql", "delete from nodes")
+    assert code == 1 and "read-only" in err
+    _, err, code = cli("sql", "update nodes set cc=0")
+    assert code == 1
+
+
+def test_sql_truncation(cli):
+    out, _, _ = cli("sql", "select id from nodes", "-n", "3")
+    assert "[truncated at 3" in out
+
+
+# --- index lifecycle -------------------------------------------------------
+
+def test_auto_build_and_stale_rebuild(tmp_path):
+    p = tmp_path / "g.json"
+    write_graph(p)
+    out, err, code = run_cli(str(p), "stats")
+    assert code == 0 and "building one-time index" in err
+    # unchanged -> no rebuild
+    _, err, _ = run_cli(str(p), "stats")
+    assert "building" not in err and "stale" not in err
+    # touched -> rebuild
+    later = time.time() + 30
+    os.utime(p, (later, later))
+    out, err, code = run_cli(str(p), "stats")
+    assert code == 0 and "stale" in err
+    assert "nodes: 5" in out
+
+
+def test_dedup_counts_in_index(graph_file):
+    g = codegraph.G(graph_file + ".idx.sqlite")
+    try:
+        rows = g.db.execute(
+            "SELECT n FROM edges WHERE src=? AND dst=?",
+            (ID[RUN], ID[conftest.HELPER])).fetchall()
+        assert rows == [(2,)]  # two raw edges -> one row with n=2
+    finally:
+        g.db.close()

--- a/tools/codegraph/tests/test_find.py
+++ b/tools/codegraph/tests/test_find.py
@@ -1,0 +1,320 @@
+# Copyright (c) 2026 Soroush Dalili
+# SPDX-License-Identifier: MIT
+
+"""Tests for the `find` pattern command, against a small resolved-style graph
+(attributes, modifiers, members) like the csharp_roslyn / csharp_cecil output.
+
+Topology:
+  Dto (class, public)  [Serializable], implements ISerializable
+    - ctor Dto()                 constructor public, parameterless
+    - prop Name                  property public get set
+    - prop Id                    property public get      (read-only)
+  Plain (class, public)          no [Serializable]
+    - ctor Plain(int x)          constructor public, HAS params
+    - prop Val                   property public get set
+  Helper (class, internal)
+    - method Load()              calls Foo.Deserialize (ext)
+"""
+
+import json
+
+import pytest
+
+import codegraph
+from conftest import run_cli
+
+
+def _n(nid, kind, mods=None, params=None, ret=None):
+    d = {"id": nid, "name": nid, "kind": kind}
+    if mods is not None:
+        d["modifiers"] = mods
+    if params is not None:
+        d["parameters"] = params
+    if ret is not None:
+        d["return_type"] = ret
+    return d
+
+
+def build(path):
+    nodes = {
+        "T:App.Dto": _n("T:App.Dto", "class", ["public"]),
+        "M:App.Dto.#ctor": _n("App.Dto:Dto.#ctor", "constructor", ["public"]),
+        "P:App.Dto.Name": _n("App.Dto:Dto.Name", "property", ["public", "get", "set"]),
+        "P:App.Dto.Id": _n("App.Dto:Dto.Id", "property", ["public", "get"]),
+        "T:App.Plain": _n("T:App.Plain", "class", ["public"]),
+        "M:App.Plain.#ctor": _n("App.Plain:Plain.#ctor", "constructor", ["public"],
+                                params=[{"name": "x", "type": "int"}]),
+        "P:App.Plain.Val": _n("App.Plain:Plain.Val", "property", ["public", "get", "set"]),
+        "T:App.Helper": _n("T:App.Helper", "class", ["internal"]),
+        "M:App.Helper.Load": _n("App.Helper:Helper.Load", "method", ["public"]),
+        # gadget scenario: SubDto extends the Dto gadget; Consumer has a field
+        # of type Dto (uses it) and overrides Dto.Name.
+        "T:App.SubDto": _n("T:App.SubDto", "class", ["public"]),
+        "T:App.Consumer": _n("T:App.Consumer", "class", ["public"]),
+        "F:App.Consumer.gadget": _n("App.Consumer:Consumer.gadget", "field",
+                                    ["private"], ret="Dto"),
+        "P:App.Consumer.Name": _n("App.Consumer:Consumer.Name", "property",
+                                  ["public", "get", "set", "override"]),
+        # ObjectDataProvider-shaped: a class with a method that calls *invoke*,
+        # a public settable property, and a public parameterless ctor.
+        "T:App.Provider": _n("T:App.Provider", "class", ["public"]),
+        "M:App.Provider.#ctor": _n("App.Provider:Provider.#ctor", "constructor", ["public"]),
+        "M:App.Provider.Run": _n("App.Provider:Provider.Run", "method", ["public"]),
+        "P:App.Provider.MethodName": _n("App.Provider:Provider.MethodName", "property",
+                                       ["public", "get", "set"]),
+    }
+    edges = [
+        {"source": "T:App.Dto", "target": "T:System.SerializableAttribute",
+         "kind": "has_attribute", "confidence": "certain"},
+        {"source": "T:App.Dto",
+         "target": "T:System.Runtime.Serialization.ISerializable",
+         "kind": "implements", "confidence": "certain"},
+        {"source": "T:App.Dto", "target": "M:App.Dto.#ctor", "kind": "contains",
+         "confidence": "certain"},
+        {"source": "T:App.Dto", "target": "P:App.Dto.Name", "kind": "contains",
+         "confidence": "certain"},
+        {"source": "T:App.Dto", "target": "P:App.Dto.Id", "kind": "contains",
+         "confidence": "certain"},
+        {"source": "T:App.Plain", "target": "M:App.Plain.#ctor", "kind": "contains",
+         "confidence": "certain"},
+        {"source": "T:App.Plain", "target": "P:App.Plain.Val", "kind": "contains",
+         "confidence": "certain"},
+        {"source": "T:App.Helper", "target": "M:App.Helper.Load", "kind": "contains",
+         "confidence": "certain"},
+        {"source": "M:App.Helper.Load", "target": "Foo.Deserialize",
+         "kind": "calls", "confidence": "certain"},
+        # SubDto inherits Dto
+        {"source": "T:App.SubDto", "target": "T:App.Dto", "kind": "inherits",
+         "confidence": "certain"},
+        {"source": "T:App.Consumer", "target": "F:App.Consumer.gadget",
+         "kind": "contains", "confidence": "certain"},
+        {"source": "T:App.Consumer", "target": "P:App.Consumer.Name",
+         "kind": "contains", "confidence": "certain"},
+        # Consumer.gadget field is of type Dto (uses the gadget)
+        {"source": "F:App.Consumer.gadget", "target": "T:App.Dto",
+         "kind": "type_uses", "confidence": "certain"},
+        # Consumer.Name overrides Dto.Name
+        {"source": "P:App.Consumer.Name", "target": "P:App.Dto.Name",
+         "kind": "overrides", "confidence": "certain"},
+        # Provider: ctor + invoking method + settable property
+        {"source": "T:App.Provider", "target": "M:App.Provider.#ctor",
+         "kind": "contains", "confidence": "certain"},
+        {"source": "T:App.Provider", "target": "M:App.Provider.Run",
+         "kind": "contains", "confidence": "certain"},
+        {"source": "T:App.Provider", "target": "P:App.Provider.MethodName",
+         "kind": "contains", "confidence": "certain"},
+        {"source": "M:App.Provider.Run", "target": "System.Reflection.MethodBase.Invoke",
+         "kind": "calls", "confidence": "certain"},
+        # ctor -> Run -> Invoke : a 2-hop chain for reachability tests
+        {"source": "M:App.Provider.#ctor", "target": "M:App.Provider.Run",
+         "kind": "calls", "confidence": "certain"},
+    ]
+    data = {
+        "language": "csharp", "root_path": "C:\\app",
+        "summary": {"total_nodes": len(nodes), "functions": 2, "classes": 3,
+                    "call_edges": 1, "dependencies": ["App", "System"],
+                    "entrypoints": 0, "resolved_calls": 1},
+        "nodes": nodes, "edges": edges, "subgraphs": {},
+    }
+    path.write_bytes(b"\xff\xfe" + json.dumps(data).encode("utf-16-le"))
+    codegraph.build_index(str(path), str(path) + ".idx.sqlite", quiet=True)
+    return str(path)
+
+
+@pytest.fixture(scope="module")
+def fg(tmp_path_factory):
+    return build(tmp_path_factory.mktemp("find") / "g.json")
+
+
+def ids(out):
+    return {i["id"] for i in json.loads(out)["items"]}
+
+
+def cli(fg, *args):
+    return run_cli(fg, *args)
+
+
+# --- single predicates -------------------------------------------------------
+
+def test_kind_only(fg):
+    out, _, _ = cli(fg, "find", "--kind", "class", "--json")
+    # Dto, Plain, Helper, SubDto, Consumer, Provider (ids by insertion order)
+    assert ids(out) == {0, 4, 7, 9, 10, 13}
+
+
+def test_attr(fg):
+    out, _, _ = cli(fg, "find", "--kind", "class", "--attr", "serializable", "--json")
+    assert ids(out) == {0}  # only Dto
+
+
+def test_implements(fg):
+    out, _, _ = cli(fg, "find", "--implements", "iserializable", "--json")
+    assert ids(out) == {0}
+
+
+def test_node_mods(fg):
+    out, _, _ = cli(fg, "find", "--kind", "class", "--mods", "internal", "--json")
+    assert ids(out) == {7}  # Helper
+
+
+def test_calls(fg):
+    out, _, _ = cli(fg, "find", "--kind", "method", "--calls", "deserialize", "--json")
+    assert ids(out) == {8}  # Helper.Load
+
+
+# --- member predicates -------------------------------------------------------
+
+def test_member_parameterless_ctor(fg):
+    out, _, _ = cli(fg, "find", "--kind", "class",
+                    "--member", "constructor:public,params=0", "--json")
+    # Dto and Provider (Plain's ctor has params, Helper/SubDto/Consumer have none)
+    assert ids(out) == {0, 13}
+
+
+def test_member_ctor_with_params(fg):
+    out, _, _ = cli(fg, "find", "--kind", "class",
+                    "--member", "constructor:params=+", "--json")
+    assert ids(out) == {4}  # Plain
+
+
+def test_member_readwrite_property(fg):
+    out, _, _ = cli(fg, "find", "--kind", "class",
+                    "--member", "property:public,get,set", "--json")
+    # Dto, Plain, Consumer, Provider all have a public get/set property
+    assert ids(out) == {0, 4, 10, 13}
+
+
+def test_member_calls_condition(fg):
+    # class with a method that calls something *invoke* (gadget behavior)
+    out, _, _ = cli(fg, "find", "--kind", "class",
+                    "--member", "method:calls=invoke", "--json")
+    assert ids(out) == {13}  # Provider
+
+
+def test_member_uses_condition(fg):
+    # class with a field whose type references the Dto gadget
+    out, _, _ = cli(fg, "find", "--kind", "class",
+                    "--member", "field:uses=app.dto", "--json")
+    assert ids(out) == {10}  # Consumer
+
+
+def test_member_type_condition(fg):
+    # field whose declared TYPE is Dto (matches the ret column; works for
+    # primitives too, unlike uses=)
+    out, _, _ = cli(fg, "find", "--kind", "class",
+                    "--member", "field:type=dto", "--json")
+    assert ids(out) == {10}  # Consumer.gadget : Dto
+
+
+def test_reaches_multihop(fg):
+    # Provider.#ctor (#14) -> Run -> Invoke : reaches "invoke" in 2 hops
+    out, _, _ = cli(fg, "find", "--kind", "constructor", "--reaches", "invoke", "--json")
+    assert ids(out) == {14}
+
+
+def test_reaches_depth_bound(fg):
+    # with only 1 hop allowed, the ctor cannot reach Invoke (it's 2 hops)
+    out, _, _ = cli(fg, "find", "--kind", "constructor", "--reaches", "invoke",
+                    "--reach-depth", "1", "--json")
+    assert ids(out) == set()
+
+
+def test_reaches_direct_method(fg):
+    # Provider.Run (#15) calls Invoke directly
+    out, _, _ = cli(fg, "find", "--kind", "method", "--reaches", "invoke", "--json")
+    assert ids(out) == {15}
+
+
+def test_reached_by_reverse(fg):
+    # the Invoke ext node is reachable FROM Provider.Run (externals are numbered
+    # after the 17 real nodes, in edge order: SerializableAttribute=17,
+    # ISerializable=18, Foo.Deserialize=19, MethodBase.Invoke=20)
+    out, _, _ = cli(fg, "find", "--reached-by", "provider.run", "--json")
+    assert 20 in ids(out)
+
+
+def test_member_reaches_bridge_gadget(fg):
+    # the headline bridge-gadget rule: a class with a constructor that
+    # transitively REACHES a target (here Provider.#ctor -> Run -> Invoke).
+    out, _, _ = cli(fg, "find", "--kind", "class",
+                    "--member", "constructor:reaches=invoke", "--json")
+    assert ids(out) == {13}  # Provider only
+
+
+def test_member_reaches_depth_bound(fg):
+    # at depth 1 the ctor reaches Run but not Invoke (2 hops) -> no match
+    out, _, _ = cli(fg, "find", "--kind", "class",
+                    "--member", "constructor:reaches=invoke",
+                    "--reach-depth", "1", "--json")
+    assert ids(out) == set()
+
+
+def test_objectdataprovider_shape(fg):
+    # the behavioral gadget rule: invoking method + settable prop + parameterless ctor
+    out, _, _ = cli(fg, "find", "--kind", "class",
+                    "--member", "method:calls=invoke",
+                    "--member", "property:public,set",
+                    "--member", "constructor:public,params=0", "--json")
+    assert ids(out) == {13}  # Provider
+
+
+# --- gadget / relationship predicates ---------------------------------------
+
+def test_find_inherits(fg):
+    # classes that extend the Dto gadget
+    out, _, _ = cli(fg, "find", "--kind", "class", "--inherits", "app.dto", "--json")
+    assert ids(out) == {9}  # SubDto
+
+
+def test_find_uses(fg):
+    # members whose signature references the Dto gadget type
+    out, _, _ = cli(fg, "find", "--uses", "app.dto", "--json")
+    assert ids(out) == {11}  # Consumer.gadget field
+
+
+def test_find_overrides(fg):
+    out, _, _ = cli(fg, "find", "--overrides", "dto.name", "--json")
+    assert ids(out) == {12}  # Consumer.Name overrides Dto.Name
+
+
+def test_callers_subclasses_of_gadget(fg):
+    # the recommended "who extends gadget #0" query
+    out, _, _ = cli(fg, "callers", "0", "--kind", "inherits", "--json")
+    assert {i["id"] for i in json.loads(out)["items"]} == {9}
+
+
+def test_callers_users_of_gadget(fg):
+    # the recommended "who references gadget #0 in a signature" query
+    out, _, _ = cli(fg, "callers", "0", "--kind", "type_uses", "--json")
+    assert {i["id"] for i in json.loads(out)["items"]} == {11}
+
+
+# --- the motivating conjunction ---------------------------------------------
+
+def test_serializable_roundtrippable_pattern(fg):
+    # [Serializable] (BinaryFormatter) + public parameterless ctor + public
+    # read/write property (Json.NET round-trip) => Dto only.
+    out, _, _ = cli(fg, "find", "--kind", "class",
+                    "--attr", "serializable",
+                    "--member", "constructor:public,params=0",
+                    "--member", "property:public,get,set", "--json")
+    assert ids(out) == {0}
+
+
+def test_conjunction_excludes_non_serializable(fg):
+    # Plain has the ctor+property shape but no [Serializable] -> excluded.
+    out, _, _ = cli(fg, "find", "--kind", "class", "--attr", "serializable",
+                    "--member", "property:public,get,set", "--json")
+    assert ids(out) == {0}
+
+
+def test_no_predicates_errors(fg):
+    _, err, code = cli(fg, "find")
+    assert code != 0 and "at least one predicate" in err
+
+
+def test_text_output_and_no_match(fg):
+    out, _, _ = cli(fg, "find", "--kind", "class", "--attr", "nosuchattr")
+    assert "no matches" in out
+    out, _, _ = cli(fg, "find", "--kind", "class", "--attr", "serializable")
+    assert "#0" in out and "cls" in out

--- a/tools/codegraph/tests/test_mcp.py
+++ b/tools/codegraph/tests/test_mcp.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2026 Soroush Dalili
+# SPDX-License-Identifier: MIT
+
+"""MCP stdio server round-trip: speaks real JSON-RPC to a subprocess."""
+
+import json
+import os
+import subprocess
+import sys
+
+CODEGRAPH = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                      "codegraph.py")
+
+
+def rpc(id_, method, **params):
+    m = {"jsonrpc": "2.0", "id": id_, "method": method}
+    if params:
+        m["params"] = params
+    return m
+
+
+def test_mcp_roundtrip(graph_file):
+    msgs = [
+        rpc(1, "initialize", protocolVersion="2024-11-05", capabilities={},
+            clientInfo={"name": "test", "version": "0"}),
+        {"jsonrpc": "2.0", "method": "notifications/initialized"},
+        rpc(2, "tools/list"),
+        rpc(3, "tools/call", name="graph_stats", arguments={}),
+        rpc(4, "tools/call", name="graph_search", arguments={"text": "cls.run"}),
+        rpc(5, "tools/call", name="graph_callees",
+            arguments={"ref": "#2", "depth": 2}),
+        rpc(6, "tools/call", name="graph_sql",
+            arguments={"query": "select count(*) as c from nodes"}),
+        rpc(7, "tools/call", name="graph_node", arguments={"ref": "zzz_nope"}),
+        rpc(8, "tools/call", name="graph_node", arguments={}),  # missing arg
+        rpc(9, "tools/call", name="no_such_tool", arguments={}),
+        rpc(10, "nonexistent/method"),
+        # array argument (calls) must round-trip into repeated CLI flags
+        rpc(11, "tools/call", name="graph_find",
+            arguments={"kind": "method", "calls": ["helper"]}),
+    ]
+    inp = "".join(json.dumps(m) + "\n" for m in msgs)
+    r = subprocess.run(
+        [sys.executable, CODEGRAPH, "mcp", "--graph", graph_file],
+        input=inp, capture_output=True, text=True, encoding="utf-8", timeout=120)
+    assert r.returncode == 0, r.stderr
+    resp = {}
+    for line in r.stdout.splitlines():
+        if line.strip():
+            m = json.loads(line)
+            if "id" in m:
+                resp[m["id"]] = m
+
+    init = resp[1]["result"]
+    assert init["serverInfo"]["name"] == "codegraph"
+    assert init["protocolVersion"] == "2024-11-05"
+    assert init["capabilities"] == {"tools": {}}
+
+    tools = {t["name"]: t for t in resp[2]["result"]["tools"]}
+    # exactly the focused tool set -- tool schemas cost agent-context tokens
+    assert set(tools) == {"graph_stats", "graph_search", "graph_find",
+                          "graph_node", "graph_callers", "graph_callees",
+                          "graph_path", "graph_sql"}
+    assert tools["graph_search"]["inputSchema"]["required"] == ["text"]
+    assert tools["graph_path"]["inputSchema"]["properties"]["undirected"][
+        "type"] == "boolean"
+    # graph_find's repeatable predicates are typed as string arrays
+    assert tools["graph_find"]["inputSchema"]["properties"]["member"][
+        "type"] == "array"
+
+    def content(i):
+        return resp[i]["result"]["content"][0]["text"]
+
+    stats = json.loads(content(3))
+    assert stats["nodes"] == 5
+
+    search = json.loads(content(4))
+    assert search["total"] == 1 and search["items"][0]["label"] == "Cls.Run"
+
+    callees = json.loads(content(5))
+    assert {i["id"] for i in callees["items"]} == {3, 4, 5, 7}
+
+    sqlres = json.loads(content(6))
+    assert sqlres["rows"][0][0] == 8
+
+    # not-found is useful feedback, not a tool error
+    nf = resp[7]["result"]
+    assert nf["isError"] is False and "no node matches" in nf["content"][0]["text"]
+
+    missing = resp[8]["result"]
+    assert missing["isError"] is True and "missing required" in missing["content"][0]["text"]
+
+    unknown = resp[9]["result"]
+    assert unknown["isError"] is True and "unknown tool" in unknown["content"][0]["text"]
+
+    assert resp[10]["error"]["code"] == -32601
+
+    # graph_find with an array predicate: methods calling something matching
+    # "helper" -> Cls.Run (#2) calls Helper
+    find = resp[11]["result"]
+    assert find["isError"] is False
+    assert 2 in {i["id"] for i in json.loads(find["content"][0]["text"])["items"]}

--- a/tools/codegraph/tests/test_unit.py
+++ b/tools/codegraph/tests/test_unit.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2026 Soroush Dalili
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for the pure helpers: label derivation, escaping, value
+coercion, and the UTF-16 -> UTF-8 streaming transcoder."""
+
+import io
+import json
+
+import codegraph
+
+
+# --- unescape / make_label --------------------------------------------------
+
+def test_unescape():
+    assert codegraph.unescape("a\\.b") == "a.b"
+    assert codegraph.unescape("plain") == "plain"
+    # lone backslashes (windows paths) are preserved
+    assert codegraph.unescape("all\\System.x") == "all\\System.x"
+
+
+def test_make_label_member():
+    # part after the last ':' wins
+    assert codegraph.make_label("a\\.b.C:D.E") == "D.E"
+    assert codegraph.make_label("x.dll.Ns.Cls:Cls.Method") == "Cls.Method"
+
+
+def test_make_label_module():
+    # last segment split on unescaped '.', then unescaped
+    assert codegraph.make_label("app\\.dll.App.Mod") == "Mod"
+    assert codegraph.make_label("a.b.Date\\.Hijri\\.debug") == "Date.Hijri.debug"
+
+
+def test_make_label_no_separator():
+    assert codegraph.make_label("noseparator") == "noseparator"
+    # all dots escaped -> whole id, unescaped
+    assert codegraph.make_label("Date\\.Hijri\\.debug") == "Date.Hijri.debug"
+
+
+# --- value coercion ----------------------------------------------------------
+
+def test_fmt_param():
+    assert codegraph.fmt_param({"name": "x", "type": "int"}) == "int x"
+    assert codegraph.fmt_param({"name": "x"}) == "x"
+    assert codegraph.fmt_param({"type": "int"}) == "int"
+    assert codegraph.fmt_param("y") == "y"
+    assert codegraph.fmt_param({}) == "?"
+
+
+def test_as_text():
+    assert codegraph.as_text(None) is None
+    assert codegraph.as_text("s") == "s"
+    assert codegraph.as_text({"name": "void"}) == "void"
+    assert codegraph.as_text({"type": "int"}) == "int"
+    assert "z" in str(codegraph.as_text({"z": 1}))  # falls back to JSON
+    assert codegraph.as_text([1, 2]) == "[1, 2]"
+
+
+def test_kind_abbrev():
+    assert codegraph.kind_abbrev("method") == "fn"
+    assert codegraph.kind_abbrev("class") == "cls"
+    assert codegraph.kind_abbrev("external") == "ext"
+    assert codegraph.kind_abbrev("weirdkind") == "weir"
+
+
+# --- UTF-16 -> UTF-8 transcoder ----------------------------------------------
+
+def test_u16_transcode_chunked():
+    # odd-sized reads must not split UTF-16 code units incorrectly;
+    # includes a surrogate pair (4 UTF-16 bytes)
+    text = '{"a": "héllo \U0001f30d", "b": [1, 2]}'
+    w = codegraph.U16ToU8(io.BytesIO(text.encode("utf-16-le")))
+    out = bytearray()
+    while True:
+        b = w.read(7)
+        if not b:
+            break
+        out += b
+    assert bytes(out).decode("utf-8") == text
+
+
+def test_u16_read_all():
+    text = '{"k": "v"}'
+    w = codegraph.U16ToU8(io.BytesIO(text.encode("utf-16-le")))
+    assert w.read().decode("utf-8") == text
+
+
+def test_u16_readinto():
+    text = '{"k": 1}'
+    w = codegraph.U16ToU8(io.BytesIO(text.encode("utf-16-le")))
+    out = bytearray()
+    buf = bytearray(5)
+    while True:
+        n = w.readinto(buf)
+        if not n:
+            break
+        out += buf[:n]
+    assert bytes(out).decode("utf-8") == text
+
+
+# --- encoding detection ------------------------------------------------------
+
+def _roundtrip(tmp_path, name, raw):
+    p = tmp_path / name
+    p.write_bytes(raw)
+    src, f = codegraph.open_json_bytes(str(p))
+    try:
+        return json.loads(src.read().decode("utf-8"))
+    finally:
+        f.close()
+
+
+def test_open_json_bytes_encodings(tmp_path):
+    doc = {"a": 1}
+    text = json.dumps(doc)
+    assert _roundtrip(tmp_path, "u16bom.json",
+                      b"\xff\xfe" + text.encode("utf-16-le")) == doc
+    assert _roundtrip(tmp_path, "u8bom.json",
+                      b"\xef\xbb\xbf" + text.encode("utf-8")) == doc
+    assert _roundtrip(tmp_path, "u8.json", text.encode("utf-8")) == doc
+    # BOM-less UTF-16 LE is sniffed via the zero byte
+    assert _roundtrip(tmp_path, "u16.json", text.encode("utf-16-le")) == doc

--- a/tools/reversing/.gitignore
+++ b/tools/reversing/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/tools/reversing/LICENSE
+++ b/tools/reversing/LICENSE
@@ -1,0 +1,22 @@
+Copyright (c) 2026 Soroush Dalili
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/tools/reversing/README.md
+++ b/tools/reversing/README.md
@@ -1,0 +1,78 @@
+# Reversing helpers
+
+These Python 3 scripts prepare and decompile .NET images during authorized analysis.
+They do not modify the input DLL or EXE files.
+
+## Dependencies
+
+Install the pinned Python packages from the repository root:
+
+```text
+python -m pip install -r tools/reversing/requirements.txt
+```
+
+Both scripts use `pefile` to inspect images. The optional `--include-filter` also uses
+`pywin32` to read Windows version resources. The requirements file installs `pywin32`
+only on Windows.
+
+`decompile-dotnet.py` also needs one supported decompiler:
+
+- JustDecompile: install the desktop application, or pass its executable with `--dcpath`.
+- ILSpy: install `ilspycmd` and put it on `PATH`.
+- dnSpy: put `dnSpy.Console.exe` on `PATH`, or pass its path with `--dcpath`.
+
+Run either script with `--help` to see every option. Help works even when the optional
+Python packages are not installed.
+
+## Decompile a directory
+
+```text
+python decompile-dotnet.py --dcname ilspy --srcdir input --destdir output --force-mkdir
+```
+
+The script:
+
+- scans DLL and EXE names case-insensitively;
+- skips native PE files;
+- passes subprocess arguments without a shell, so spaces and shell characters in paths
+  are handled as data;
+- mirrors each input's relative path below the destination, or uses a stable hashed name
+  with `--use-hashed-name`;
+- returns a nonzero exit code when a decompiler process fails or produces no files.
+
+dnSpy normally handles a whole tree in one process. Add `--normalise-dnspy` to run it once
+per image. Per-file features such as `--unique-files`, `--include-filter`, and
+`--use-hashed-name` require that mode.
+
+The destination must be outside the source tree. This prevents an old decompilation from
+being discovered as new input during a later run.
+
+## Make framework images easier to debug
+
+```text
+python dotnet-image-deoptimizer.py --target input --recursive
+```
+
+For a managed `MyApp.exe` or `MyApp.dll`, the script creates `MyApp.ini` beside it with
+the .NET Framework debugging-control settings. Existing INI files are not overwritten.
+
+On Windows, the default also persists `COMPlus_ZapDisable=1` and
+`COMPlus_ReadyToRun=1` for the current user by calling `setx`. Use
+`--environment-scope machine` from an elevated shell for machine-wide values, `both` for
+both scopes, or `none` to create only the INI files. A `setx` change affects processes
+started after the command, not processes that are already running.
+
+## Tests
+
+The tests use fakes for PE parsing, version resources, and decompiler processes, so they
+do not require Windows, the Python dependencies, or a decompiler:
+
+```text
+python -m unittest discover -s tools/reversing/tests -p "test_*.py"
+```
+
+## License
+
+Copyright (c) 2026 Soroush Dalili. Licensed under the same MIT License as YSoNet. See
+[`LICENSE`](LICENSE). The copyright and permission notices must remain in all copies or
+substantial portions of these tools.

--- a/tools/reversing/decompile-dotnet.py
+++ b/tools/reversing/decompile-dotnet.py
@@ -1,0 +1,485 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Soroush Dalili
+# SPDX-License-Identifier: MIT
+
+"""Decompile .NET DLL and EXE files from a directory tree."""
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import shlex
+import shutil
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+from reversing_common import (
+    DependencyError,
+    collect_image_files,
+    hash_file,
+    is_dotnet_image,
+    is_within,
+    matches_include_filter,
+    require_pefile,
+    require_win32api,
+)
+
+
+DECOMPILER_FILENAMES = {
+    "justdecompile": "JustDecompile.exe",
+    "ilspy": "ilspycmd",
+    "dnspy": "dnSpy.Console.exe",
+}
+
+
+def positive_int(value):
+    number = int(value)
+    if number < 1:
+        raise argparse.ArgumentTypeError("must be at least 1")
+    return number
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(
+        description="Decompile .NET DLL and EXE files from a directory tree."
+    )
+    parser.add_argument(
+        "-dcn",
+        "--dcname",
+        choices=("justdecompile", "ilspy", "dnspy"),
+        default="justdecompile",
+        help="Decompiler to run (default: justdecompile).",
+    )
+    parser.add_argument(
+        "-normalise-dnspy",
+        "--normalise-dnspy",
+        "--normdnspy",
+        action="store_true",
+        dest="normdnspy",
+        help="Run dnSpy once per file so this script's filters and naming options apply.",
+    )
+    parser.add_argument(
+        "-dcp",
+        "--dcpath",
+        default="",
+        help="Decompiler executable or containing directory (default: find it on PATH).",
+    )
+    parser.add_argument(
+        "-s", "--srcdir", required=True, help="Directory containing DLL and EXE files."
+    )
+    parser.add_argument(
+        "-d", "--destdir", required=True, help="Directory in which to save decompiled files."
+    )
+    parser.add_argument(
+        "-fmd",
+        "--force-mkdir",
+        action="store_true",
+        dest="force_mkdir",
+        help="Create the destination directory when it does not exist.",
+    )
+    parser.add_argument(
+        "-mt",
+        "--max-thread",
+        type=positive_int,
+        default=1,
+        dest="max_thread",
+        help="Maximum parallel decompiler processes (default: 1).",
+    )
+    parser.add_argument(
+        "-uhn",
+        "--use-hashed-name",
+        action="store_true",
+        dest="use_hashed_name",
+        help=(
+            "Use an MD5 digest of each relative input path as its output directory name. "
+            "The relative path is saved in decompiled_file.txt."
+        ),
+    )
+    parser.add_argument(
+        "-uf",
+        "--unique-files",
+        action="store_true",
+        dest="unique_files",
+        help="Decompile only the first file for each SHA-256 content digest.",
+    )
+    parser.add_argument(
+        "-if",
+        "--include-filter",
+        default="",
+        dest="inc_filter",
+        help=(
+            "Include files whose Windows StringFileInfo contains this text. "
+            "Files with no LegalCopyright value are always included."
+        ),
+    )
+    return parser
+
+
+def default_justdecompile_path():
+    program_files = os.environ.get("ProgramFiles(x86)") or os.environ.get("ProgramFiles")
+    if not program_files:
+        return "JustDecompile.exe"
+    return str(
+        Path(program_files)
+        / "Telerik"
+        / "JustDecompile"
+        / "Libraries"
+        / "JustDecompile.exe"
+    )
+
+
+def resolve_decompiler(name, requested_path="", which=shutil.which):
+    """Resolve an executable name, file, or containing directory."""
+    requested = requested_path.strip()
+    if not requested:
+        if name == "justdecompile":
+            installed = Path(default_justdecompile_path())
+            if installed.is_file():
+                return str(installed.resolve())
+        requested = DECOMPILER_FILENAMES[name]
+
+    candidate = Path(os.path.expandvars(os.path.expanduser(requested)))
+    if candidate.is_dir():
+        names = [DECOMPILER_FILENAMES[name]]
+        if name == "ilspy":
+            names.append("ilspycmd.exe")
+        for filename in names:
+            executable = candidate / filename
+            if executable.is_file():
+                return str(executable.resolve())
+        raise ValueError(
+            "Decompiler executable was not found in directory: {0}".format(candidate)
+        )
+
+    has_directory = candidate.is_absolute() or candidate.parent != Path(".")
+    if has_directory:
+        if candidate.is_file():
+            return str(candidate.resolve())
+        raise ValueError("Decompiler executable was not found: {0}".format(candidate))
+
+    resolved = which(str(candidate))
+    if resolved:
+        return str(Path(resolved).resolve())
+    raise ValueError(
+        "Decompiler executable '{0}' was not found on PATH. Use --dcpath to specify it.".format(
+            candidate
+        )
+    )
+
+
+def dnspy_common_arguments():
+    return (
+        "--no-resources",
+        "--no-resx",
+        "--no-baml",
+        "--vs",
+        "2019",
+        "--dont-remove-new-delegate-class",
+        "--dont-remove-empty-ctors",
+    )
+
+
+def build_file_command(decompiler_name, executable, source_file, output_dir):
+    source_file = str(source_file)
+    output_dir = str(output_dir)
+    if decompiler_name == "justdecompile":
+        return [
+            executable,
+            "/target:{0}".format(source_file),
+            "/out:{0}".format(output_dir + os.sep),
+            "/lang:csharp",
+            "/vs:2017",
+        ]
+    if decompiler_name == "ilspy":
+        return [executable, source_file, "-p", "-o", output_dir]
+    return [
+        executable,
+        "--no-sln",
+        *dnspy_common_arguments(),
+        "-o",
+        output_dir,
+        source_file,
+    ]
+
+
+def build_dnspy_bulk_command(executable, source_dir, output_dir, threads):
+    return [
+        executable,
+        *dnspy_common_arguments(),
+        "--threads",
+        str(threads),
+        "-r",
+        "-o",
+        str(output_dir),
+        str(source_dir),
+    ]
+
+
+def display_command(command):
+    if os.name == "nt":
+        return subprocess.list2cmdline(command)
+    return shlex.join(command)
+
+
+def run_command(command, runner=subprocess.run):
+    print(display_command(command))
+    try:
+        result = runner(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            shell=False,
+        )
+    except OSError as exc:
+        print("Decompiler could not be started: {0}".format(exc), file=sys.stderr)
+        return False
+
+    if result.stdout:
+        print(result.stdout.rstrip())
+    if result.stderr:
+        print(result.stderr.rstrip(), file=sys.stderr)
+    if result.returncode != 0:
+        print(
+            "Decompiler exited with code {0}.".format(result.returncode), file=sys.stderr
+        )
+        return False
+    return True
+
+
+def relative_input_path(source_file, source_dir):
+    try:
+        return Path(source_file).resolve().relative_to(Path(source_dir).resolve())
+    except ValueError as exc:
+        message = "Input file is outside the source directory: {0}".format(source_file)
+        raise ValueError(message) from exc
+
+
+def output_directory(source_file, source_dir, destination_dir, use_hashed_name):
+    relative = relative_input_path(source_file, source_dir)
+    if use_hashed_name:
+        digest = hashlib.md5(relative.as_posix().encode("utf-8")).hexdigest()
+        return Path(destination_dir) / digest
+    return Path(destination_dir) / relative
+
+
+def remove_empty_directory(path, created_here):
+    if not created_here:
+        return
+    try:
+        Path(path).rmdir()
+    except OSError:
+        pass
+
+
+def decompile_one(
+    source_file,
+    source_dir,
+    destination_dir,
+    decompiler_name,
+    executable,
+    use_hashed_name,
+    runner=subprocess.run,
+):
+    target_dir = output_directory(
+        source_file, source_dir, destination_dir, use_hashed_name
+    )
+    created_here = not target_dir.exists()
+    target_dir.mkdir(parents=True, exist_ok=True)
+    command = build_file_command(decompiler_name, executable, source_file, target_dir)
+    if not run_command(command, runner):
+        remove_empty_directory(target_dir, created_here)
+        return False
+
+    try:
+        has_output = any(target_dir.iterdir())
+    except OSError as exc:
+        print(
+            "Could not inspect output directory {0}: {1}".format(target_dir, exc),
+            file=sys.stderr,
+        )
+        return False
+    if not has_output:
+        print(
+            "Decompiler reported success but produced no files for {0}.".format(source_file),
+            file=sys.stderr,
+        )
+        remove_empty_directory(target_dir, created_here)
+        return False
+
+    if use_hashed_name:
+        relative = relative_input_path(source_file, source_dir).as_posix()
+        (target_dir / "decompiled_file.txt").write_text(relative + "\n", encoding="utf-8")
+    return True
+
+
+def deduplicate_files(files):
+    unique = []
+    seen = set()
+    failures = 0
+    for path in files:
+        try:
+            digest = hash_file(path)
+        except OSError as exc:
+            failures += 1
+            print("Could not hash {0}: {1}".format(path, exc), file=sys.stderr)
+            continue
+        if digest in seen:
+            print("Duplicate skipped: {0}".format(path))
+            continue
+        seen.add(digest)
+        unique.append(path)
+    return unique, failures
+
+
+def select_dotnet_files(files, pe_module):
+    selected = []
+    failures = 0
+    print("Checking image files for .NET metadata...")
+    for path in files:
+        try:
+            if is_dotnet_image(path, pe_module):
+                selected.append(path)
+            else:
+                print("Native image skipped: {0}".format(path))
+        except Exception as exc:
+            failures += 1
+            print("Unreadable image skipped: {0}: {1}".format(path, exc), file=sys.stderr)
+    print("Found {0} .NET image(s).".format(len(selected)))
+    return selected, failures
+
+
+def write_run_info(destination_dir, args, executable):
+    info = {
+        "decompiler": args.dcname,
+        "decompiler_path": executable,
+        "source_directory": str(Path(args.srcdir).resolve()),
+        "destination_directory": str(Path(args.destdir).resolve()),
+        "max_threads": args.max_thread,
+        "normalise_dnspy": args.normdnspy,
+        "use_hashed_name": args.use_hashed_name,
+        "unique_files": args.unique_files,
+        "include_filter": args.inc_filter,
+    }
+    path = Path(destination_dir) / "decompile_info.txt"
+    path.write_text(json.dumps(info, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def validate_paths(parser, args):
+    source_dir = Path(args.srcdir).expanduser().resolve()
+    destination_dir = Path(args.destdir).expanduser().resolve()
+    if not source_dir.is_dir():
+        parser.error("Source directory does not exist: {0}".format(source_dir))
+    if destination_dir == source_dir or is_within(destination_dir, source_dir):
+        parser.error("Destination directory must not be inside the source directory.")
+    if not destination_dir.is_dir():
+        if not args.force_mkdir:
+            parser.error(
+                "Destination directory does not exist and --force-mkdir is off: {0}".format(
+                    destination_dir
+                )
+            )
+        try:
+            destination_dir.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            parser.error("Could not create destination directory: {0}".format(exc))
+        print("Created destination directory: {0}".format(destination_dir))
+    return source_dir, destination_dir
+
+
+def validate_dnspy_mode(parser, args):
+    if args.dcname != "dnspy" or args.normdnspy:
+        return
+    unsupported = []
+    if args.use_hashed_name:
+        unsupported.append("--use-hashed-name")
+    if args.unique_files:
+        unsupported.append("--unique-files")
+    if args.inc_filter:
+        unsupported.append("--include-filter")
+    if unsupported:
+        parser.error(
+            "dnSpy bulk mode cannot apply {0}; add --normalise-dnspy.".format(
+                ", ".join(unsupported)
+            )
+        )
+
+
+def main(argv=None):
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    validate_dnspy_mode(parser, args)
+    source_dir, destination_dir = validate_paths(parser, args)
+
+    try:
+        executable = resolve_decompiler(args.dcname, args.dcpath)
+    except ValueError as exc:
+        parser.error(str(exc))
+    write_run_info(destination_dir, args, executable)
+
+    if args.dcname == "dnspy" and not args.normdnspy:
+        command = build_dnspy_bulk_command(
+            executable, source_dir, destination_dir, args.max_thread
+        )
+        return 0 if run_command(command) else 1
+
+    try:
+        pe_module = require_pefile()
+        win32_api = require_win32api() if args.inc_filter else None
+    except DependencyError as exc:
+        parser.error(str(exc))
+
+    files = collect_image_files(source_dir, recursive=True)
+    preprocessing_failures = 0
+    if args.unique_files:
+        files, hash_failures = deduplicate_files(files)
+        preprocessing_failures += hash_failures
+    if args.inc_filter:
+        filtered = []
+        for path in files:
+            if matches_include_filter(path, args.inc_filter, win32_api):
+                filtered.append(path)
+            else:
+                print("Version-info filter excluded: {0}".format(path))
+        files = filtered
+    files, scan_failures = select_dotnet_files(files, pe_module)
+    preprocessing_failures += scan_failures
+
+    decompile_failures = 0
+    with ThreadPoolExecutor(max_workers=args.max_thread) as executor:
+        futures = {
+            executor.submit(
+                decompile_one,
+                path,
+                source_dir,
+                destination_dir,
+                args.dcname,
+                executable,
+                args.use_hashed_name,
+            ): path
+            for path in files
+        }
+        for future in as_completed(futures):
+            path = futures[future]
+            try:
+                succeeded = future.result()
+            except Exception as exc:
+                succeeded = False
+                print("Decompile failed for {0}: {1}".format(path, exc), file=sys.stderr)
+            if not succeeded:
+                decompile_failures += 1
+
+    failures = preprocessing_failures + decompile_failures
+    print(
+        "Done: {0} decompiled, {1} failed.".format(
+            len(files) - decompile_failures,
+            failures,
+        )
+    )
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/reversing/dotnet-image-deoptimizer.py
+++ b/tools/reversing/dotnet-image-deoptimizer.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Soroush Dalili
+# SPDX-License-Identifier: MIT
+
+"""Create .NET Framework JIT-control INI files for managed images."""
+
+import argparse
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+from reversing_common import (
+    DependencyError,
+    collect_image_files,
+    is_dotnet_image,
+    matches_include_filter,
+    require_pefile,
+    require_win32api,
+)
+
+
+INI_FILE_CONTENTS = (
+    "[.NET Framework Debugging Control]\n"
+    "GenerateTrackingInfo=1\n"
+    "AllowOptimize=0\n"
+)
+COMPLUS_SETTINGS = ("COMPlus_ZapDisable", "COMPlus_ReadyToRun")
+
+
+def positive_int(value):
+    number = int(value)
+    if number < 1:
+        raise argparse.ArgumentTypeError("must be at least 1")
+    return number
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Create .NET Framework debugging-control INI files beside managed DLL and EXE "
+            "files, and optionally persist COMPlus deoptimization settings on Windows."
+        )
+    )
+    parser.add_argument(
+        "-t", "--target", required=True, dest="targetdir", help="Directory to inspect."
+    )
+    parser.add_argument(
+        "-r",
+        "--recursive",
+        action="store_true",
+        dest="isrecursive",
+        help="Inspect subdirectories (disabled by default).",
+    )
+    parser.add_argument(
+        "-mt",
+        "--max-thread",
+        type=positive_int,
+        default=1,
+        dest="max_thread",
+        help="Maximum parallel image checks (default: 1).",
+    )
+    parser.add_argument(
+        "-if",
+        "--include-filter",
+        default="",
+        dest="inc_filter",
+        help=(
+            "Include files whose Windows StringFileInfo contains this text. "
+            "Files with no LegalCopyright value are always included."
+        ),
+    )
+    parser.add_argument(
+        "--environment-scope",
+        choices=("none", "user", "machine", "both"),
+        default="user",
+        help=(
+            "Where to persist COMPlus_ZapDisable and COMPlus_ReadyToRun with setx "
+            "(default: user). Use 'none' outside Windows or to create only INI files."
+        ),
+    )
+    return parser
+
+
+def environment_commands(scope):
+    commands = []
+    if scope in ("user", "both"):
+        for name in COMPLUS_SETTINGS:
+            commands.append(["setx", name, "1"])
+    if scope in ("machine", "both"):
+        for name in COMPLUS_SETTINGS:
+            commands.append(["setx", name, "1", "/m"])
+    return commands
+
+
+def configure_environment(scope, runner=subprocess.run, which=shutil.which):
+    if scope == "none":
+        return True
+    if os.name != "nt":
+        print(
+            "COMPlus settings can only be persisted with setx on Windows. "
+            "Use --environment-scope none to create only INI files.",
+            file=sys.stderr,
+        )
+        return False
+    if not which("setx"):
+        print("setx was not found on PATH.", file=sys.stderr)
+        return False
+
+    succeeded = True
+    for command in environment_commands(scope):
+        try:
+            result = runner(
+                command,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                shell=False,
+            )
+        except OSError as exc:
+            print("Could not run setx: {0}".format(exc), file=sys.stderr)
+            succeeded = False
+            continue
+        if result.stdout:
+            print(result.stdout.rstrip())
+        if result.stderr:
+            print(result.stderr.rstrip(), file=sys.stderr)
+        if result.returncode != 0:
+            print(
+                "Environment command failed with code {0}: {1}".format(
+                    result.returncode, subprocess.list2cmdline(command)
+                ),
+                file=sys.stderr,
+            )
+            succeeded = False
+    return succeeded
+
+
+def ini_path_for_image(image_path):
+    # Microsoft documents MyApp.exe -> MyApp.ini, not MyApp.exe.ini.
+    return Path(image_path).with_suffix(".ini")
+
+
+def create_ini_file(image_path, contents=INI_FILE_CONTENTS):
+    """Create one INI without overwriting an existing sidecar."""
+    ini_path = ini_path_for_image(image_path)
+    try:
+        with open(ini_path, "x", encoding="ascii", newline="\n") as output:
+            output.write(contents)
+    except FileExistsError:
+        print("INI already exists: {0}".format(ini_path))
+        return "existing", ini_path
+    print("INI created: {0}".format(ini_path))
+    return "created", ini_path
+
+
+def process_image(image_path, pe_module):
+    try:
+        if not is_dotnet_image(image_path, pe_module):
+            print("Native image skipped: {0}".format(image_path))
+            return "skipped"
+        status, _ = create_ini_file(image_path)
+        return status
+    except Exception as exc:
+        print("Image failed: {0}: {1}".format(image_path, exc), file=sys.stderr)
+        return "failed"
+
+
+def main(argv=None):
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    target_dir = Path(args.targetdir).expanduser().resolve()
+    if not target_dir.is_dir():
+        parser.error("Target directory does not exist: {0}".format(target_dir))
+
+    try:
+        pe_module = require_pefile()
+        win32_api = require_win32api() if args.inc_filter else None
+    except DependencyError as exc:
+        parser.error(str(exc))
+
+    environment_ok = configure_environment(args.environment_scope)
+
+    files = collect_image_files(target_dir, args.isrecursive)
+    if args.inc_filter:
+        filtered = []
+        for path in files:
+            if matches_include_filter(path, args.inc_filter, win32_api):
+                filtered.append(path)
+            else:
+                print("Version-info filter excluded: {0}".format(path))
+        files = filtered
+
+    counts = {"created": 0, "existing": 0, "skipped": 0, "failed": 0}
+    with ThreadPoolExecutor(max_workers=args.max_thread) as executor:
+        futures = {executor.submit(process_image, path, pe_module): path for path in files}
+        for future in as_completed(futures):
+            path = futures[future]
+            try:
+                status = future.result()
+            except Exception as exc:
+                status = "failed"
+                print("Image failed: {0}: {1}".format(path, exc), file=sys.stderr)
+            counts[status] += 1
+
+    print(
+        "Done: {created} created, {existing} existing, {skipped} native, "
+        "{failed} failed.".format(**counts)
+    )
+    return 1 if counts["failed"] or not environment_ok else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/reversing/requirements.txt
+++ b/tools/reversing/requirements.txt
@@ -1,0 +1,5 @@
+# PE inspection for DLL and EXE files.
+pefile==2024.8.26
+
+# Windows version resources used by --include-filter.
+pywin32==312; sys_platform == "win32"

--- a/tools/reversing/reversing_common.py
+++ b/tools/reversing/reversing_common.py
@@ -1,0 +1,161 @@
+# Copyright (c) 2026 Soroush Dalili
+# SPDX-License-Identifier: MIT
+
+"""Shared helpers for the reversing command-line tools."""
+
+import hashlib
+import os
+from pathlib import Path
+
+
+IMAGE_SUFFIXES = {".dll", ".exe"}
+
+
+class DependencyError(RuntimeError):
+    """Raised when an optional runtime dependency is required but unavailable."""
+
+
+def require_pefile():
+    try:
+        import pefile
+    except ImportError as exc:
+        raise DependencyError(
+            "The pefile package is required. Install it with: python -m pip install pefile"
+        ) from exc
+    return pefile
+
+
+def require_win32api():
+    try:
+        import win32api
+    except ImportError as exc:
+        raise DependencyError(
+            "The include filter requires pywin32 on Windows. "
+            "Install it with: python -m pip install pywin32"
+        ) from exc
+    return win32api
+
+
+def is_within(path, root):
+    """Return True when path is root or is below root."""
+    try:
+        resolved_path = os.path.normcase(str(Path(path).resolve()))
+        resolved_root = os.path.normcase(str(Path(root).resolve()))
+        return os.path.commonpath((resolved_path, resolved_root)) == resolved_root
+    except ValueError:
+        # Different Windows drives have no common path.
+        return False
+
+
+def collect_image_files(root, recursive, excluded_roots=()):
+    """Collect DLL and EXE paths with case-insensitive suffix matching."""
+    root = Path(root)
+    iterator = root.rglob("*") if recursive else root.iterdir()
+    excluded = tuple(Path(item).resolve() for item in excluded_roots)
+    files = []
+    for path in iterator:
+        if not path.is_file() or path.suffix.lower() not in IMAGE_SUFFIXES:
+            continue
+        resolved = path.resolve()
+        if any(is_within(resolved, item) for item in excluded):
+            continue
+        files.append(resolved)
+    return sorted(files, key=lambda item: str(item).casefold())
+
+
+def is_dotnet_image(path, pe_module=None):
+    """Return True when a PE file has a valid CLR runtime header entry."""
+    pe_module = pe_module or require_pefile()
+    pe = None
+    try:
+        pe = pe_module.PE(str(path), fast_load=True)
+        directories = pe.OPTIONAL_HEADER.DATA_DIRECTORY
+        if len(directories) <= 14:
+            return False
+        clr_header = directories[14]
+        return bool(clr_header.VirtualAddress and clr_header.Size)
+    finally:
+        if pe is not None and callable(getattr(pe, "close", None)):
+            pe.close()
+
+
+def get_file_properties(path, win32_api=None):
+    """Read the Windows version resource, tolerating missing fields."""
+    win32_api = win32_api or require_win32api()
+    properties = {"FixedFileInfo": None, "StringFileInfo": {}, "FileVersion": ""}
+
+    try:
+        fixed_info = win32_api.GetFileVersionInfo(str(path), "\\")
+    except Exception:
+        return properties
+
+    properties["FixedFileInfo"] = fixed_info
+    try:
+        properties["FileVersion"] = "%d.%d.%d.%d" % (
+            fixed_info["FileVersionMS"] // 65536,
+            fixed_info["FileVersionMS"] % 65536,
+            fixed_info["FileVersionLS"] // 65536,
+            fixed_info["FileVersionLS"] % 65536,
+        )
+    except (KeyError, TypeError):
+        pass
+
+    try:
+        translations = win32_api.GetFileVersionInfo(str(path), "\\VarFileInfo\\Translation")
+        language, codepage = translations[0]
+    except Exception:
+        return properties
+
+    property_names = (
+        "Comments",
+        "InternalName",
+        "ProductName",
+        "CompanyName",
+        "LegalCopyright",
+        "ProductVersion",
+        "FileDescription",
+        "LegalTrademarks",
+        "PrivateBuild",
+        "FileVersion",
+        "OriginalFilename",
+        "SpecialBuild",
+    )
+    string_info = {}
+    for property_name in property_names:
+        resource_path = "\\StringFileInfo\\%04X%04X\\%s" % (
+            language,
+            codepage,
+            property_name,
+        )
+        try:
+            value = win32_api.GetFileVersionInfo(str(path), resource_path)
+        except Exception:
+            continue
+        if value is not None:
+            string_info[property_name] = str(value)
+    properties["StringFileInfo"] = string_info
+    return properties
+
+
+def matches_include_filter(path, keyword, win32_api=None):
+    """Apply the scripts' StringFileInfo and copyright filtering rule."""
+    if not keyword:
+        return True
+    string_info = get_file_properties(path, win32_api)["StringFileInfo"]
+    copyright_value = string_info.get("LegalCopyright", "").strip()
+    if not copyright_value:
+        return True
+    searchable = "\n".join(string_info.values())
+    return keyword.casefold() in searchable.casefold()
+
+
+def hash_file(path, block_size=65536):
+    """Return a SHA-256 content digest without loading the whole file."""
+    digest = hashlib.sha256()
+    with open(path, "rb") as source:
+        while True:
+            block = source.read(block_size)
+            if not block:
+                break
+            digest.update(block)
+    return digest.hexdigest()

--- a/tools/reversing/tests/test_reversing_tools.py
+++ b/tools/reversing/tests/test_reversing_tools.py
@@ -1,0 +1,324 @@
+# Copyright (c) 2026 Soroush Dalili
+# SPDX-License-Identifier: MIT
+
+"""Focused tests for the reversing command-line tools."""
+
+import argparse
+from contextlib import redirect_stderr, redirect_stdout
+import importlib.util
+import io
+from pathlib import Path
+import sys
+import tempfile
+from types import SimpleNamespace
+import unittest
+from unittest import mock
+
+
+REVERSING_DIR = Path(__file__).resolve().parent.parent
+if str(REVERSING_DIR) not in sys.path:
+    sys.path.insert(0, str(REVERSING_DIR))
+
+import reversing_common as common
+
+
+def load_script(module_name, filename):
+    spec = importlib.util.spec_from_file_location(module_name, REVERSING_DIR / filename)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+decompile = load_script("decompile_dotnet", "decompile-dotnet.py")
+deoptimizer = load_script("dotnet_image_deoptimizer", "dotnet-image-deoptimizer.py")
+
+
+class FakePE:
+    def __init__(self, virtual_address, size):
+        directories = [SimpleNamespace(VirtualAddress=0, Size=0) for _ in range(15)]
+        directories[14] = SimpleNamespace(VirtualAddress=virtual_address, Size=size)
+        self.OPTIONAL_HEADER = SimpleNamespace(DATA_DIRECTORY=directories)
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+class CommonTests(unittest.TestCase):
+    def test_collect_image_files_is_case_insensitive_and_honors_recursion(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            (root / "a.DLL").write_bytes(b"a")
+            (root / "b.txt").write_bytes(b"b")
+            nested = root / "nested"
+            nested.mkdir()
+            (nested / "c.ExE").write_bytes(b"c")
+
+            shallow = common.collect_image_files(root, recursive=False)
+            recursive = common.collect_image_files(root, recursive=True)
+
+            self.assertEqual(["a.DLL"], [path.name for path in shallow])
+            self.assertEqual(["a.DLL", "c.ExE"], [path.name for path in recursive])
+
+    def test_collect_image_files_excludes_output_tree(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            output = root / "output"
+            output.mkdir()
+            (root / "input.dll").write_bytes(b"a")
+            (output / "old.exe").write_bytes(b"b")
+
+            files = common.collect_image_files(root, True, (output,))
+
+            self.assertEqual(["input.dll"], [path.name for path in files])
+
+    def test_dotnet_detection_requires_complete_clr_header_and_closes_pe(self):
+        images = []
+
+        def make_pe(_path, fast_load):
+            self.assertTrue(fast_load)
+            image = FakePE(123, 456)
+            images.append(image)
+            return image
+
+        self.assertTrue(common.is_dotnet_image("managed.dll", SimpleNamespace(PE=make_pe)))
+        self.assertTrue(images[0].closed)
+
+        incomplete = FakePE(123, 0)
+        module = SimpleNamespace(PE=lambda _path, fast_load: incomplete)
+        self.assertFalse(common.is_dotnet_image("broken.dll", module))
+        self.assertTrue(incomplete.closed)
+
+    def test_missing_version_resource_is_included_instead_of_crashing(self):
+        api = SimpleNamespace(
+            GetFileVersionInfo=lambda _path, _field: (_ for _ in ()).throw(OSError("missing"))
+        )
+        self.assertTrue(common.matches_include_filter("plain.dll", "Microsoft", api))
+
+    def test_version_filter_is_case_insensitive(self):
+        values = {
+            "\\": {"FileVersionMS": 0, "FileVersionLS": 0},
+            "\\VarFileInfo\\Translation": [(0x409, 1200)],
+            "\\StringFileInfo\\040904B0\\LegalCopyright": "Copyright owner",
+            "\\StringFileInfo\\040904B0\\CompanyName": "Example COMPANY",
+        }
+        api = SimpleNamespace(GetFileVersionInfo=lambda _path, field: values[field])
+        self.assertTrue(common.matches_include_filter("file.dll", "company", api))
+        self.assertFalse(common.matches_include_filter("file.dll", "missing", api))
+
+
+class DecompileTests(unittest.TestCase):
+    def test_max_threads_must_be_positive(self):
+        with self.assertRaises(argparse.ArgumentTypeError):
+            decompile.positive_int("0")
+
+    def test_resolve_decompiler_uses_path_lookup(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            executable = Path(temporary) / "ilspycmd"
+            executable.write_bytes(b"tool")
+            result = decompile.resolve_decompiler(
+                "ilspy", "", which=lambda _name: str(executable)
+            )
+            self.assertEqual(str(executable.resolve()), result)
+
+    def test_resolve_ilspy_accepts_windows_executable_in_directory(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            executable = Path(temporary) / "ilspycmd.exe"
+            executable.write_bytes(b"tool")
+            result = decompile.resolve_decompiler("ilspy", temporary)
+            self.assertEqual(str(executable.resolve()), result)
+
+    def test_commands_keep_paths_with_spaces_as_single_arguments(self):
+        command = decompile.build_file_command(
+            "ilspy",
+            "tools/ilspy cmd",
+            "input files/a.dll",
+            "output files/a.dll",
+        )
+        self.assertEqual("tools/ilspy cmd", command[0])
+        self.assertEqual("input files/a.dll", command[1])
+        self.assertEqual("output files/a.dll", command[-1])
+
+    def test_dnspy_uses_correct_empty_constructor_option(self):
+        command = decompile.build_file_command("dnspy", "dnSpy.Console.exe", "a.dll", "out")
+        self.assertIn("--dont-remove-empty-ctors", command)
+        self.assertNotIn("--dont-remove-emtpy-ctors", command)
+
+    def test_output_path_stays_below_destination(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "source"
+            destination = root / "destination"
+            nested = source / "nested"
+            nested.mkdir(parents=True)
+            destination.mkdir()
+            image = nested / "sample.dll"
+            image.write_bytes(b"image")
+
+            output = decompile.output_directory(image, source, destination, False)
+
+            self.assertEqual(destination / "nested" / "sample.dll", output)
+            self.assertTrue(common.is_within(output, destination))
+
+    def test_hashed_output_records_only_relative_input_path(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "source"
+            destination = root / "destination"
+            source.mkdir()
+            destination.mkdir()
+            image = source / "sample.dll"
+            image.write_bytes(b"image")
+
+            def runner(command, **_kwargs):
+                output = Path(command[command.index("-o") + 1])
+                (output / "sample.cs").write_text("class Sample {}", encoding="utf-8")
+                return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+            with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+                succeeded = decompile.decompile_one(
+                    image, source, destination, "ilspy", "ilspycmd", True, runner
+                )
+
+            self.assertTrue(succeeded)
+            output = decompile.output_directory(image, source, destination, True)
+            self.assertEqual("sample.dll\n", (output / "decompiled_file.txt").read_text())
+            self.assertNotIn(str(root), (output / "decompiled_file.txt").read_text())
+
+    def test_failed_decompile_does_not_delete_existing_output_directory(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "source"
+            destination = root / "destination"
+            source.mkdir()
+            destination.mkdir()
+            image = source / "sample.dll"
+            image.write_bytes(b"image")
+            output = destination / "sample.dll"
+            output.mkdir()
+
+            runner = lambda _command, **_kwargs: SimpleNamespace(
+                returncode=1, stdout="", stderr="failure"
+            )
+            with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+                succeeded = decompile.decompile_one(
+                    image, source, destination, "ilspy", "ilspycmd", False, runner
+                )
+
+            self.assertFalse(succeeded)
+            self.assertTrue(output.is_dir())
+
+    def test_child_process_failure_is_reported(self):
+        runner = lambda _command, **_kwargs: SimpleNamespace(
+            returncode=7, stdout="out", stderr="error"
+        )
+        with mock.patch.object(sys, "stdout", new=io.StringIO()), mock.patch.object(
+            sys, "stderr", new=io.StringIO()
+        ):
+            self.assertFalse(decompile.run_command(["tool", "file.dll"], runner))
+
+    def test_deduplication_uses_content_and_reports_no_failure(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            first = root / "first.dll"
+            second = root / "second.dll"
+            first.write_bytes(b"same")
+            second.write_bytes(b"same")
+
+            with redirect_stdout(io.StringIO()):
+                selected, failures = decompile.deduplicate_files([first, second])
+
+            self.assertEqual([first], selected)
+            self.assertEqual(0, failures)
+
+    def test_unreadable_pe_is_counted_as_a_failure(self):
+        pe_module = SimpleNamespace(
+            PE=lambda _path, fast_load: (_ for _ in ()).throw(OSError("unreadable"))
+        )
+        with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+            selected, failures = decompile.select_dotnet_files([Path("bad.dll")], pe_module)
+        self.assertEqual([], selected)
+        self.assertEqual(1, failures)
+
+    def test_dnspy_bulk_rejects_per_file_features(self):
+        parser = decompile.build_parser()
+        args = parser.parse_args(
+            [
+                "--dcname",
+                "dnspy",
+                "--srcdir",
+                "source",
+                "--destdir",
+                "destination",
+                "--unique-files",
+            ]
+        )
+        with mock.patch.object(sys, "stderr", new=io.StringIO()):
+            with self.assertRaises(SystemExit):
+                decompile.validate_dnspy_mode(parser, args)
+
+
+class DeoptimizerTests(unittest.TestCase):
+    def test_max_threads_must_be_positive(self):
+        with self.assertRaises(argparse.ArgumentTypeError):
+            deoptimizer.positive_int("-1")
+
+    def test_ini_name_and_contents_match_framework_convention(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            image = Path(temporary) / "MyApp.exe"
+            image.write_bytes(b"image")
+
+            with redirect_stdout(io.StringIO()):
+                status, ini_path = deoptimizer.create_ini_file(image)
+
+            self.assertEqual("created", status)
+            self.assertEqual(Path(temporary) / "MyApp.ini", ini_path)
+            self.assertEqual(deoptimizer.INI_FILE_CONTENTS, ini_path.read_text(encoding="ascii"))
+
+    def test_existing_ini_is_not_overwritten(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            image = Path(temporary) / "Library.dll"
+            image.write_bytes(b"image")
+            ini_path = Path(temporary) / "Library.ini"
+            ini_path.write_text("custom", encoding="ascii")
+
+            with redirect_stdout(io.StringIO()):
+                status, _ = deoptimizer.create_ini_file(image)
+
+            self.assertEqual("existing", status)
+            self.assertEqual("custom", ini_path.read_text(encoding="ascii"))
+
+    def test_environment_scope_builds_separate_argv_commands(self):
+        self.assertEqual(
+            [
+                ["setx", "COMPlus_ZapDisable", "1"],
+                ["setx", "COMPlus_ReadyToRun", "1"],
+                ["setx", "COMPlus_ZapDisable", "1", "/m"],
+                ["setx", "COMPlus_ReadyToRun", "1", "/m"],
+            ],
+            deoptimizer.environment_commands("both"),
+        )
+
+    def test_environment_scope_none_never_runs_a_process(self):
+        runner = mock.Mock(side_effect=AssertionError("runner called"))
+        self.assertTrue(deoptimizer.configure_environment("none", runner=runner))
+        runner.assert_not_called()
+
+    def test_setx_failure_is_not_reported_as_success(self):
+        runner = mock.Mock(
+            return_value=SimpleNamespace(returncode=1, stdout="", stderr="access denied")
+        )
+        with mock.patch.object(deoptimizer.os, "name", "nt"), mock.patch.object(
+            sys, "stderr", new=io.StringIO()
+        ):
+            succeeded = deoptimizer.configure_environment(
+                "user", runner=runner, which=lambda _name: "setx.exe"
+            )
+        self.assertFalse(succeeded)
+        self.assertEqual(2, runner.call_count)
+        for call in runner.call_args_list:
+            self.assertFalse(call.kwargs["shell"])
+            self.assertIsInstance(call.args[0], list)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
…aph skill

Adds tools/codegraph (C# code-graph query CLI + tests) and tools/reversing (.NET decompile/deoptimize helpers + tests), the ysonet-codegraph skill that queries the graph, and a workflow memory note. Ignores a local/ dir. The nested tool .gitignore files exclude __pycache__/ and .pytest_cache/ so only source is tracked.

<!-- Base must be irsdl/ysonet:master. If you see a different base, change it via the dropdowns. -->

### Summary

### Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] **Breaking change** -> call it out clearly in the summary above

### Checklist
- [ ] PR targets **irsdl/ysonet:master**
- [ ] Builds pass (see CI)
